### PR TITLE
[#27] feat(capsue): 시간 기반 내게쓰기 캡슐 생성 기능 구현

### DIFF
--- a/src/components/capsule/new/left/VisibilityOpt.tsx
+++ b/src/components/capsule/new/left/VisibilityOpt.tsx
@@ -22,6 +22,12 @@ export default function VisibilityOpt({
         title="공개"
         desc="모두 공개"
       />
+      <OptionCard
+        selected={value === "MYSELF"}
+        onClick={() => onChange("MYSELF")}
+        title="내게쓰기"
+        desc="나만 보기"
+      />
     </div>
   );
 }

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -133,10 +133,6 @@ export default function WriteForm() {
       window.alert("내용을 입력해 주세요.");
       return;
     }
-    if (!dayForm.date || !dayForm.time) {
-      window.alert("해제 날짜와 시간을 모두 입력해 주세요.");
-      return;
-    }
     // 비공개 캡슐일 경우에만 검증
     if (isPrivateOnly) {
       if (sendMethod === "PHONE" && !phoneNum) {

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -189,6 +189,7 @@ export default function WriteForm() {
     const privatePayload = buildPrivatePayload({
       memberId: me.memberId,
       senderName,
+      receiverNickname: receiveName,
       title,
       content: contentValue,
       visibility: effectiveVisibility,

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -13,7 +13,7 @@ import ActionTab from "./ActionTab";
 import VisibilityOpt from "./VisibilityOpt";
 import WriteInput from "./WriteInput";
 import UnlockConditionTabs from "./UnlockConditionTabs";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import DayTime from "./unlockOpt/DayTime";
 import Location from "./unlockOpt/Location";
 import DayLocation from "./unlockOpt/DayLocation";
@@ -70,6 +70,13 @@ export default function WriteForm() {
   const isPrivateOnly = visibility === "PRIVATE";
   const isSelf = visibility === "MYSELF";
   const effectiveVisibility: Visibility = isSelf ? "PRIVATE" : visibility;
+
+  // 공개 선택 시 TIME 옵션을 사용하지 않도록 강제
+  useEffect(() => {
+    if (visibility === "PUBLIC" && unlockType === "TIME") {
+      setUnlockType("LOCATION");
+    }
+  }, [visibility, unlockType]);
 
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const next = e.target.value;
@@ -158,6 +165,12 @@ export default function WriteForm() {
       unlockType === "MANUAL"
         ? "TIME_AND_LOCATION"
         : (unlockType as UnlockType);
+
+    // 공개 캡슐은 장소 기반이어야 함 (TIME만 선택 불가)
+    if (visibility === "PUBLIC" && effectiveUnlockType === "TIME") {
+      window.alert("공개 캡슐은 '장소' 또는 '시간+장소'만 선택할 수 있습니다.");
+      return;
+    }
 
     // 시간/위치 필수 검증 (unlockType에 따라)
     if (
@@ -407,27 +420,49 @@ export default function WriteForm() {
 
         <WriteDiv title="해제 조건">
           <div className="space-y-3">
+            {visibility === "PUBLIC" && (
+              <p className="text-xs text-text-3">
+                공개 캡슐은 지도 노출을 위해 장소 기반이어야 합니다.
+              </p>
+            )}
             <UnlockConditionTabs
-              tabs={[
-                {
-                  id: "TIME",
-                  title: "시간",
-                  description: "특정 날짜와 시간에 열람",
-                  icon: <Clock size={20} />,
-                },
-                {
-                  id: "LOCATION",
-                  title: "장소",
-                  description: "특정 장소에 도착 시 열람",
-                  icon: <MapPin size={20} />,
-                },
-                {
-                  id: "MANUAL",
-                  title: "시간 + 장소",
-                  description: "시간과 장소 모두 충족 시 열람",
-                  icon: <Hand size={20} />,
-                },
-              ]}
+              tabs={
+                visibility === "PUBLIC"
+                  ? [
+                      {
+                        id: "LOCATION",
+                        title: "장소",
+                        description: "특정 장소에 도착 시 열람",
+                        icon: <MapPin size={20} />,
+                      },
+                      {
+                        id: "MANUAL",
+                        title: "시간 + 장소",
+                        description: "시간과 장소 모두 충족 시 열람",
+                        icon: <Hand size={20} />,
+                      },
+                    ]
+                  : [
+                      {
+                        id: "TIME",
+                        title: "시간",
+                        description: "특정 날짜와 시간에 열람",
+                        icon: <Clock size={20} />,
+                      },
+                      {
+                        id: "LOCATION",
+                        title: "장소",
+                        description: "특정 장소에 도착 시 열람",
+                        icon: <MapPin size={20} />,
+                      },
+                      {
+                        id: "MANUAL",
+                        title: "시간 + 장소",
+                        description: "시간과 장소 모두 충족 시 열람",
+                        icon: <Hand size={20} />,
+                      },
+                    ]
+              }
               value={unlockType}
               onChange={setUnlockType}
             />

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -358,7 +358,7 @@ export default function WriteForm() {
               onCompositionStart={() => (isComposingRef.current = true)}
               onCompositionEnd={handleCompositionEnd}
               maxLength={MAX_CONTENT_LENGTH}
-              className="w-full h-60 bg-sub-2 p-3 rounded-lg resize-none"
+              className="w-full h-60 bg-sub-2 p-3 rounded-lg resize-none outline-none border border-white focus:border focus:border-primary-2"
               placeholder="마음을 담아 편지를 써보세요..."
             />
 

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -209,7 +209,7 @@ export default function WriteForm() {
             })
           : await createPublicCapsule(publicPayload);
       const baseResult = {
-        userName: senderName || data?.nickName || "",
+        userName: senderName || data?.nickname || "",
         url: data?.url || "",
         password: data?.capPW,
       };

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -336,44 +336,6 @@ export default function WriteForm() {
           </WriteDiv>
         )}
 
-        {isPrivateOnly && (
-          <WriteDiv title="전달 방법">
-            <div className="space-y-3">
-              <ActionTab
-                value={sendMethod}
-                onChange={setSendMethod}
-                tabs={[
-                  { id: "URL", tabName: "비밀번호" },
-                  { id: "PHONE", tabName: "전화번호" },
-                ]}
-              />
-              {sendMethod === "PHONE" ? (
-                <WriteDiv
-                  title="받는 사람 전화번호"
-                  warning="* 회원으로 등록된 전화번호만 사용할 수 있습니다."
-                >
-                  <WriteInput
-                    id="pagePw"
-                    type="text"
-                    placeholder="- 없이 입력"
-                  />
-                </WriteDiv>
-              ) : (
-                <WriteDiv
-                  title="편지 열람 비밀번호"
-                  warning="* 상대방이 해당 편지를 확인하기 위해 사용하는 비밀번호입니다."
-                >
-                  <WriteInput
-                    id="pagePw"
-                    type="password"
-                    placeholder="비밀번호를 입력하세요."
-                  />
-                </WriteDiv>
-              )}
-            </div>
-          </WriteDiv>
-        )}
-
         <WriteDiv
           title="편지 제목"
           warning="* 상대방이 편지를 열지 않아도 볼 수 있는 제목입니다. 공개를 원하지 않는 내용은 작성을 삼가 주세요."
@@ -412,6 +374,10 @@ export default function WriteForm() {
 
             <input type="hidden" name="content" value={content} />
           </div>
+        </WriteDiv>
+
+        <WriteDiv title="이미지 첨부 (선택사항)">
+          <div></div>
         </WriteDiv>
 
         <WriteDiv title="해제 조건">
@@ -481,9 +447,43 @@ export default function WriteForm() {
           </div>
         </WriteDiv>
 
-        <WriteDiv title="이미지 첨부 (선택사항)">
-          <div></div>
-        </WriteDiv>
+        {isPrivateOnly && (
+          <WriteDiv title="인증 방법">
+            <div className="space-y-3">
+              <ActionTab
+                value={sendMethod}
+                onChange={setSendMethod}
+                tabs={[
+                  { id: "URL", tabName: "비밀번호" },
+                  { id: "PHONE", tabName: "전화번호" },
+                ]}
+              />
+              {sendMethod === "PHONE" ? (
+                <WriteDiv
+                  title="받는 사람 전화번호"
+                  warning="* 회원으로 등록된 전화번호만 사용할 수 있습니다."
+                >
+                  <WriteInput
+                    id="pagePw"
+                    type="text"
+                    placeholder="- 없이 입력"
+                  />
+                </WriteDiv>
+              ) : (
+                <WriteDiv
+                  title="편지 열람 비밀번호"
+                  warning="* 상대방이 해당 편지를 확인하기 위해 사용하는 비밀번호입니다."
+                >
+                  <WriteInput
+                    id="pagePw"
+                    type="password"
+                    placeholder="비밀번호를 입력하세요."
+                  />
+                </WriteDiv>
+              )}
+            </div>
+          </WriteDiv>
+        )}
 
         <Button type="submit" className="w-full py-4 space-x-2">
           <Send />

--- a/src/components/capsule/new/modal/CopyTemplate.tsx
+++ b/src/components/capsule/new/modal/CopyTemplate.tsx
@@ -1,6 +1,20 @@
+import { useEffect } from "react";
 import Modal from "@/components/common/Modal";
 import Button from "@/components/common/Button";
 import { Check } from "lucide-react";
+
+async function copyWithClipboardAPI(text: string) {
+  if (!text.trim()) return;
+  try {
+    if (!navigator.clipboard || !window.isSecureContext) {
+      throw new Error("Clipboard API not available");
+    }
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    console.error("Clipboard copy failed", error);
+    alert("클립보드 복사에 실패했습니다. 브라우저 설정을 확인해 주세요.");
+  }
+}
 
 export default function CopyTemplate({
   open,
@@ -13,6 +27,31 @@ export default function CopyTemplate({
   onConfirm?: () => void;
   data: { userName: string; url: string; password?: string } | null;
 }) {
+  // 복사할 메시지
+  const shareText = `[Dear.___] 편지 전송 안내
+${
+  data?.userName ?? ""
+}님으로부터 편지가 도착했습니다. 아래의 링크를 통해 편지 세부 내용을 확인하실 수 있습니다.
+
+접속 URL: ${data?.url ?? ""}
+${data?.password ? `비밀번호: ${data.password}` : ""}
+
+※ 편지 내용을 저장하거나 보관함에 추가하시려면 로그인이 필요합니다.
+
+궁금한 점이 있으시면 Dear.___ 고객센터로 문의해주세요.
+감사합니다.`;
+
+  // Clipboard API 사용
+  const copyToClipboard = async () => {
+    await copyWithClipboardAPI(shareText);
+  };
+
+  useEffect(() => {
+    if (open && data?.userName) {
+      void copyWithClipboardAPI(shareText);
+    }
+  }, [open, data?.userName, data?.url, data?.password, shareText]);
+
   return (
     <Modal open={open} onClose={onClose}>
       <div className="w-full max-w-[520px] flex flex-col items-center gap-3 md:gap-5 rounded-2xl border-2 border-outline bg-white p-4 md:p-6">
@@ -28,17 +67,14 @@ export default function CopyTemplate({
         </div>
         <div className="border border-outline p-6 bg-sub rounded-xl">
           <pre className="text-text-4 text-sm md:text-base whitespace-pre-wrap break-keep">
-            {`[Dear.___] 편지 전송 안내 \n${
-              data?.userName
-            }님으로부터 편지가 도착했습니다. 아래의 링크를 통해 편지 세부 내용을 확인하실 수 있습니다.\n
-    접속 URL: ${data?.url}
-    ${
-      data?.password ? `비밀번호: ${data.password}` : ""
-    }\n\n※ 편지 내용을 저장하거나 보관함에 추가하시려면 로그인이 필요합니다.\n\n궁금한 점이 있으시면 Dear.___ 고객센터로 문의해주세요.\n감사합니다.`}
+            {shareText}
           </pre>
         </div>
         <div className="w-full flex gap-4">
-          <Button className="w-full py-1.5 md:py-3 text-text bg-white border-2 border-primary-3 text-sm md:text-base md:font-normal hover:text-white hover:border-primary-2">
+          <Button
+            className="w-full py-1.5 md:py-3 text-text bg-white border-2 border-primary-3 text-sm md:text-base md:font-normal hover:text-white hover:border-primary-2"
+            onClick={copyToClipboard}
+          >
             클립보드 복사
           </Button>
           <Button

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -45,7 +45,7 @@ export function buildPrivatePayload(
 
   return {
     memberId,
-    nickName: senderName,
+    nickname: senderName,
     title,
     content,
     visibility,

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -10,6 +10,7 @@ import {
 type BuildCommonArgs = {
   memberId: number;
   senderName: string;
+  receiverNickname?: string;
   title: string;
   content: string;
   visibility: Visibility;
@@ -91,6 +92,7 @@ export function buildPrivatePayload(
   const {
     memberId,
     senderName,
+    receiverNickname = "",
     title,
     content,
     visibility,
@@ -107,6 +109,7 @@ export function buildPrivatePayload(
   return {
     memberId,
     nickname: senderName,
+    receiverNickname,
     title,
     content,
     visibility,

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -17,6 +17,26 @@ export interface CreatePrivateCapsuleRequest {
   maxViewCount: number;
 }
 
+export interface CreateMyCapsuleRequest {
+  memberId: number;
+  nickname: string;
+  receiverNickname: string;
+  title: string;
+  content: string;
+  visibility: Visibility;
+  unlockType: UnlockType;
+  unlockAt?: string;
+  unlockUntil?: string;
+  locationName: string;
+  address?: string;
+  locationLat: number;
+  locationLng: number;
+  viewingRadius: number;
+  packingColor: string;
+  contentColor: string;
+  maxViewCount: number;
+}
+
 export interface CreatePublicCapsuleRequest {
   memberId: number;
   nickname: string;
@@ -39,6 +59,7 @@ export interface CapsuleCreateResponse {
   memberId: number;
   capsuleId: number;
   nickname?: string;
+  receiverNickname?: string;
   title: string;
   content: string;
   visibility: string;

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -2,7 +2,7 @@ export type UnlockType = "TIME" | "LOCATION" | "TIME_AND_LOCATION";
 
 export interface CreatePrivateCapsuleRequest {
   memberId: number;
-  nickName: string;
+  nickname: string;
   title: string;
   content: string;
   visibility: Visibility;
@@ -38,7 +38,7 @@ export interface CreatePublicCapsuleRequest {
 export interface CapsuleCreateResponse {
   memberId: number;
   capsuleId: number;
-  nickName?: string;
+  nickname?: string;
   title: string;
   content: string;
   visibility: string;

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -3,6 +3,7 @@ export type UnlockType = "TIME" | "LOCATION" | "TIME_AND_LOCATION";
 export interface CreatePrivateCapsuleRequest {
   memberId: number;
   nickname: string;
+  receiverNickname: string;
   title: string;
   content: string;
   visibility: Visibility;

--- a/src/type/newCapsule.d.ts
+++ b/src/type/newCapsule.d.ts
@@ -1,4 +1,4 @@
-type Visibility = "PRIVATE" | "PUBLIC";
+type Visibility = "PRIVATE" | "PUBLIC" | "MYSELF";
 
 type DayForm = {
   date: string; // "2025-12-12"


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
시간 기반 내게쓰기 캡슐 생성 기능 구현

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #27 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 내게 쓰기 API 연결
- [x] 내게 쓰기일 경우 보내는 사람 이름에 로그인한 사용자 이름이 들어가도록 구현
- [x] 해제조건, 인증 방법 폼을 이미지 첨부 폼 아래로 이동
- [x] 공개 캡슐일 경우, 시간 단일 조건 선택 폼이 나타나지 않도록 수정
- [x] 수정된 캡슐 생성 DTO에 맞춰 nickName에서 nickname으로 네이밍 변경 사항 적용
- [x] 수정된 캡슐 생성 DTO에 맞춰 receiverNickname에 수신자 닉네임 보내도록 구현
- [x] 편지 내용 outline 개선
- [x] 비공개 편지 생성 완료 시  Clipboard API 를 이용해서 복사되도록 구현

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="1041" height="254" alt="image" src="https://github.com/user-attachments/assets/c79b4504-fdfc-4960-b506-fd8eb9e9758c" />
<img width="1043" height="1093" alt="image" src="https://github.com/user-attachments/assets/9a6e59be-a85b-4bbe-a835-eb9b6929cbe1" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

1. 편지지, 편지봉투 색상 선택 구현예정입니다.
2. 현재 테이블에 존재하지 않은 전화번호를 넣어도 통과가 되는 중. 이 부분 알아봐야 할 것 같습니다.
3. 내게쓰기의 경우, 전화번호를 로그인 한 유저의 전화번호를 넘겨주어야 하는데 문제가 있습니다.
 3-1. 로그인 한 유저 정보에서 전화번호가 010-****-5678 처럼 마스킹 되어 있습니다.
 3-2. 이 때문에 로그인 한 유저의 전화번호를 넘겨주기 어렵습니다.
 3-3. 이 부분 문의하여 마스킹을 지우거나, 전화번호를 유저가 입력하는 방향으로 해야할 것 같습니다. 
