### PR TITLE
[#46] chore(capsule): 캡슐 생성 DTO 변경된 스펙 반영

### DIFF
--- a/src/components/capsule/new/WritePage.tsx
+++ b/src/components/capsule/new/WritePage.tsx
@@ -22,7 +22,7 @@ export default function WritePage() {
           <div className="w-full lg:w-1/2 overflow-y-auto">
             <Left preview={preview} onPreviewChange={setPreview} />
           </div>
-          <div className="w-1/2 hidden lg:block border-l border-outline">
+          <div className="w-1/2 hidden lg:flex border-l border-outline overflow-hidden min-h-0">
             <Right preview={preview} />
           </div>
         </div>

--- a/src/components/capsule/new/WritePage.tsx
+++ b/src/components/capsule/new/WritePage.tsx
@@ -11,7 +11,7 @@ export default function WritePage() {
     senderName: "",
     receiverName: "",
     content: "",
-    visibility: "PRIVATE" as Visibility | "MYSELF",
+    visibility: "PRIVATE" as Visibility | "SELF",
     authMethod: "URL",
     unlockType: "TIME",
     charCount: 0,

--- a/src/components/capsule/new/WritePage.tsx
+++ b/src/components/capsule/new/WritePage.tsx
@@ -1,8 +1,18 @@
+"use client";
+
+import { useState } from "react";
 import Left from "./left/Left";
 import Right from "./right/Right";
 import WriteHeader from "./WriteHeader";
 
 export default function WritePage() {
+  const [preview, setPreview] = useState({
+    title: "",
+    senderName: "",
+    receiverName: "",
+    content: "",
+  });
+
   return (
     <>
       <div className="h-screen flex flex-col">
@@ -10,10 +20,10 @@ export default function WritePage() {
 
         <div className="flex flex-1 flex-col lg:flex-row overflow-hidden bg-sub">
           <div className="w-full lg:w-1/2 overflow-y-auto">
-            <Left />
+            <Left preview={preview} onPreviewChange={setPreview} />
           </div>
           <div className="w-1/2 hidden lg:block border-l border-outline">
-            <Right />
+            <Right preview={preview} />
           </div>
         </div>
       </div>

--- a/src/components/capsule/new/WritePage.tsx
+++ b/src/components/capsule/new/WritePage.tsx
@@ -11,6 +11,10 @@ export default function WritePage() {
     senderName: "",
     receiverName: "",
     content: "",
+    visibility: "PRIVATE" as Visibility | "MYSELF",
+    authMethod: "URL",
+    unlockType: "TIME",
+    charCount: 0,
   });
 
   return (

--- a/src/components/capsule/new/left/Left.tsx
+++ b/src/components/capsule/new/left/Left.tsx
@@ -5,6 +5,10 @@ type PreviewState = {
   senderName: string;
   receiverName: string;
   content: string;
+  visibility: Visibility | "MYSELF";
+  authMethod: string;
+  unlockType: string;
+  charCount: number;
 };
 
 export default function Left({

--- a/src/components/capsule/new/left/Left.tsx
+++ b/src/components/capsule/new/left/Left.tsx
@@ -1,19 +1,23 @@
 import WriteForm from "./WriteForm";
-export default function Left() {
-  /*  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
 
-    const payload = {
-      visibility, // 여기로 전달됨
-    };
+type PreviewState = {
+  title: string;
+  senderName: string;
+  receiverName: string;
+  content: string;
+};
 
-    console.log(payload);
-  }; */
-
+export default function Left({
+  preview,
+  onPreviewChange,
+}: {
+  preview: PreviewState;
+  onPreviewChange: (next: PreviewState) => void;
+}) {
   return (
     <>
       <section className="p-8">
-        <WriteForm />
+        <WriteForm preview={preview} onPreviewChange={onPreviewChange} />
       </section>
     </>
   );

--- a/src/components/capsule/new/left/Left.tsx
+++ b/src/components/capsule/new/left/Left.tsx
@@ -5,7 +5,7 @@ type PreviewState = {
   senderName: string;
   receiverName: string;
   content: string;
-  visibility: Visibility | "MYSELF";
+  visibility: Visibility | "SELF";
   authMethod: string;
   unlockType: string;
   charCount: number;

--- a/src/components/capsule/new/left/VisibilityOpt.tsx
+++ b/src/components/capsule/new/left/VisibilityOpt.tsx
@@ -22,6 +22,12 @@ export default function VisibilityOpt({
         title="공개"
         desc="모두 공개"
       />
+      <OptionCard
+        selected={value === "MYSELF"}
+        onClick={() => onChange("MYSELF")}
+        title="내게쓰기"
+        desc="나만 보기"
+      />
     </div>
   );
 }

--- a/src/components/capsule/new/left/VisibilityOpt.tsx
+++ b/src/components/capsule/new/left/VisibilityOpt.tsx
@@ -23,8 +23,8 @@ export default function VisibilityOpt({
         desc="모두 공개"
       />
       <OptionCard
-        selected={value === "MYSELF"}
-        onClick={() => onChange("MYSELF")}
+        selected={value === "SELF"}
+        onClick={() => onChange("SELF")}
         title="내게쓰기"
         desc="나만 보기"
       />

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -133,10 +133,6 @@ export default function WriteForm() {
       window.alert("내용을 입력해 주세요.");
       return;
     }
-    if (!dayForm.date || !dayForm.time) {
-      window.alert("해제 날짜와 시간을 모두 입력해 주세요.");
-      return;
-    }
     // 비공개 캡슐일 경우에만 검증
     if (isPrivateOnly) {
       if (sendMethod === "PHONE" && !phoneNum) {

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -285,16 +285,9 @@ export default function WriteForm({
 
       const data = isSelf
         ? await (async () => {
-            const phoneRaw = me.phoneNumber || "";
-            const phoneDigits = phoneRaw.replace(/\D/g, "");
-            if (!phoneDigits) {
-              throw new Error("로그인 정보에서 전화번호를 확인할 수 없습니다.");
-            }
             const myPayload = buildMyPayload({
               memberId: me.memberId,
               senderName,
-              recipientPhone: phoneDigits,
-              capsulePassword: null,
               title,
               content: contentValue,
               visibility: effectiveVisibility,

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -30,7 +30,10 @@ import {
   buildMyPayload,
   createMyCapsule,
 } from "@/lib/api/capsule/capsule";
-import type { UnlockType } from "@/lib/api/capsule/types";
+import type {
+  UnlockType,
+  CapsuleCreateResponse,
+} from "@/lib/api/capsule/types";
 
 type PreviewState = {
   title: string;
@@ -304,10 +307,18 @@ export default function WriteForm({
         : isPrivateOnly
         ? await createPrivateCapsule(privatePayload)
         : await createPublicCapsule(publicPayload);
+
+      // 응답은 { code, message, data } 래핑 형태로 옴
+      const result = (data as unknown as { data: CapsuleCreateResponse }).data;
+
+      const url = result?.url ?? "";
+      const password = result?.capPW;
+      const userName = senderName || result?.nickname || "";
+
       const baseResult = {
-        userName: senderName || data?.nickname || "",
-        url: data?.url || "",
-        password: data?.capPW,
+        userName,
+        url,
+        password,
       };
 
       if (isPrivateOnly) {

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -189,6 +189,7 @@ export default function WriteForm() {
     const privatePayload = buildPrivatePayload({
       memberId: me.memberId,
       senderName,
+      receiverNickname: receiveName,
       title,
       content: contentValue,
       visibility: effectiveVisibility,

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -37,6 +37,10 @@ type PreviewState = {
   senderName: string;
   receiverName: string;
   content: string;
+  visibility: Visibility | "MYSELF";
+  authMethod: string;
+  unlockType: string;
+  charCount: number;
 };
 
 export default function WriteForm({
@@ -90,13 +94,50 @@ export default function WriteForm({
 
   // 미리보기 데이터 동기화
   useEffect(() => {
+    const visibilityLabel =
+      // 공개 범위
+      visibility === "PUBLIC"
+        ? "PUBLIC"
+        : visibility === "MYSELF"
+        ? "MYSELF"
+        : "PRIVATE";
+    // 인증 방법
+    const authMethodLabel =
+      visibility === "PUBLIC"
+        ? "NONE"
+        : visibility === "MYSELF"
+        ? "NONE"
+        : sendMethod === "PHONE"
+        ? "PHONE"
+        : "PASSWORD";
+    // 해제 조건
+    const unlockLabel =
+      unlockType === "LOCATION"
+        ? "LOCATION"
+        : unlockType === "MANUAL"
+        ? "TIME_AND_LOCATION"
+        : "TIME";
+
     onPreviewChange({
       title,
       senderName,
       receiverName: receiveName,
       content,
+      visibility: visibilityLabel,
+      authMethod: authMethodLabel,
+      unlockType: unlockLabel,
+      charCount: content.length,
     });
-  }, [title, senderName, receiveName, content, onPreviewChange]);
+  }, [
+    title,
+    senderName,
+    receiveName,
+    content,
+    visibility,
+    sendMethod,
+    unlockType,
+    onPreviewChange,
+  ]);
 
   // 공개 선택 시 TIME 옵션을 사용하지 않도록 강제
   useEffect(() => {

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -40,7 +40,7 @@ type PreviewState = {
   senderName: string;
   receiverName: string;
   content: string;
-  visibility: Visibility | "MYSELF";
+  visibility: Visibility | "SELF";
   authMethod: string;
   unlockType: string;
   charCount: number;
@@ -89,8 +89,8 @@ export default function WriteForm({
   /* 한글 입력 중인지 체크 (조합 중엔 강제 slice 하면 입력이 깨질 수 있음) */
   const isComposingRef = useRef(false);
   const isPrivateOnly = visibility === "PRIVATE";
-  const isSelf = visibility === "MYSELF";
-  const effectiveVisibility: Visibility = isSelf ? "PRIVATE" : visibility;
+  const isSelf = visibility === "SELF";
+  const effectiveVisibility: Visibility = isSelf ? "SELF" : visibility;
 
   const senderName =
     senderMode === "nickname" ? me?.nickname || "" : me?.name || "";
@@ -101,14 +101,14 @@ export default function WriteForm({
       // 공개 범위
       visibility === "PUBLIC"
         ? "PUBLIC"
-        : visibility === "MYSELF"
-        ? "MYSELF"
+        : visibility === "SELF"
+        ? "SELF"
         : "PRIVATE";
     // 인증 방법
     const authMethodLabel =
       visibility === "PUBLIC"
         ? "NONE"
-        : visibility === "MYSELF"
+        : visibility === "SELF"
         ? "NONE"
         : sendMethod === "PHONE"
         ? "PHONE"

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -13,7 +13,7 @@ import ActionTab from "./ActionTab";
 import VisibilityOpt from "./VisibilityOpt";
 import WriteInput from "./WriteInput";
 import UnlockConditionTabs from "./UnlockConditionTabs";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import DayTime from "./unlockOpt/DayTime";
 import Location from "./unlockOpt/Location";
 import DayLocation from "./unlockOpt/DayLocation";
@@ -70,6 +70,13 @@ export default function WriteForm() {
   const isPrivateOnly = visibility === "PRIVATE";
   const isSelf = visibility === "MYSELF";
   const effectiveVisibility: Visibility = isSelf ? "PRIVATE" : visibility;
+
+  // 공개 선택 시 TIME 옵션을 사용하지 않도록 강제
+  useEffect(() => {
+    if (visibility === "PUBLIC" && unlockType === "TIME") {
+      setUnlockType("LOCATION");
+    }
+  }, [visibility, unlockType]);
 
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const next = e.target.value;
@@ -158,6 +165,12 @@ export default function WriteForm() {
       unlockType === "MANUAL"
         ? "TIME_AND_LOCATION"
         : (unlockType as UnlockType);
+
+    // 공개 캡슐은 장소 기반이어야 함 (TIME만 선택 불가)
+    if (visibility === "PUBLIC" && effectiveUnlockType === "TIME") {
+      window.alert("공개 캡슐은 '장소' 또는 '시간+장소'만 선택할 수 있습니다.");
+      return;
+    }
 
     // 시간/위치 필수 검증 (unlockType에 따라)
     if (
@@ -407,27 +420,49 @@ export default function WriteForm() {
 
         <WriteDiv title="해제 조건">
           <div className="space-y-3">
+            {visibility === "PUBLIC" && (
+              <p className="text-xs text-text-3">
+                공개 캡슐은 지도 노출을 위해 장소 기반이어야 합니다.
+              </p>
+            )}
             <UnlockConditionTabs
-              tabs={[
-                {
-                  id: "TIME",
-                  title: "시간",
-                  description: "특정 날짜와 시간에 열람",
-                  icon: <Clock size={20} />,
-                },
-                {
-                  id: "LOCATION",
-                  title: "장소",
-                  description: "특정 장소에 도착 시 열람",
-                  icon: <MapPin size={20} />,
-                },
-                {
-                  id: "MANUAL",
-                  title: "시간 + 장소",
-                  description: "시간과 장소 모두 충족 시 열람",
-                  icon: <Hand size={20} />,
-                },
-              ]}
+              tabs={
+                visibility === "PUBLIC"
+                  ? [
+                      {
+                        id: "LOCATION",
+                        title: "장소",
+                        description: "특정 장소에 도착 시 열람",
+                        icon: <MapPin size={20} />,
+                      },
+                      {
+                        id: "MANUAL",
+                        title: "시간 + 장소",
+                        description: "시간과 장소 모두 충족 시 열람",
+                        icon: <Hand size={20} />,
+                      },
+                    ]
+                  : [
+                      {
+                        id: "TIME",
+                        title: "시간",
+                        description: "특정 날짜와 시간에 열람",
+                        icon: <Clock size={20} />,
+                      },
+                      {
+                        id: "LOCATION",
+                        title: "장소",
+                        description: "특정 장소에 도착 시 열람",
+                        icon: <MapPin size={20} />,
+                      },
+                      {
+                        id: "MANUAL",
+                        title: "시간 + 장소",
+                        description: "시간과 장소 모두 충족 시 열람",
+                        icon: <Hand size={20} />,
+                      },
+                    ]
+              }
               value={unlockType}
               onChange={setUnlockType}
             />

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -121,10 +121,13 @@ export default function WriteForm({
         ? "TIME_AND_LOCATION"
         : "TIME";
 
+    // 내게쓰기일 경우 받는 사람 이름을 보내는 사람 이름으로 설정
+    const receiverLabel = isSelf ? senderName : receiveName;
+
     onPreviewChange({
       title,
       senderName,
-      receiverName: receiveName,
+      receiverName: receiverLabel,
       content,
       visibility: visibilityLabel,
       authMethod: authMethodLabel,
@@ -135,6 +138,7 @@ export default function WriteForm({
     title,
     senderName,
     receiveName,
+    isSelf,
     content,
     visibility,
     sendMethod,
@@ -175,7 +179,11 @@ export default function WriteForm({
 
     const formData = new FormData(e.currentTarget);
     const titleValue = title.trim();
-    const receiveNameValue = isPrivateOnly ? receiveName.trim() : "";
+    const receiveNameValue = isSelf
+      ? senderName
+      : isPrivateOnly
+      ? receiveName.trim()
+      : "";
     const contentValue = content.trim();
     const phoneNum =
       visibility === "PRIVATE" && sendMethod === "PHONE"

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -358,7 +358,7 @@ export default function WriteForm() {
               onCompositionStart={() => (isComposingRef.current = true)}
               onCompositionEnd={handleCompositionEnd}
               maxLength={MAX_CONTENT_LENGTH}
-              className="w-full h-60 bg-sub-2 p-3 rounded-lg resize-none"
+              className="w-full h-60 bg-sub-2 p-3 rounded-lg resize-none outline-none border border-white focus:border focus:border-primary-2"
               placeholder="마음을 담아 편지를 써보세요..."
             />
 

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -209,7 +209,7 @@ export default function WriteForm() {
             })
           : await createPublicCapsule(publicPayload);
       const baseResult = {
-        userName: senderName || data?.nickName || "",
+        userName: senderName || data?.nickname || "",
         url: data?.url || "",
         password: data?.capPW,
       };

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -253,6 +253,8 @@ export default function WriteForm({
       memberId: me.memberId,
       senderName,
       receiverNickname: receiveNameValue,
+      recipientPhone: phoneNum || null,
+      capsulePassword: capsulePassword || null,
       title: titleValue,
       content: contentValue,
       visibility: effectiveVisibility,
@@ -288,6 +290,8 @@ export default function WriteForm({
             const myPayload = buildMyPayload({
               memberId: me.memberId,
               senderName,
+              recipientPhone: phoneDigits,
+              capsulePassword: null,
               title,
               content: contentValue,
               visibility: effectiveVisibility,
@@ -295,13 +299,10 @@ export default function WriteForm({
               dayForm,
               locationForm,
             });
-            return createMyCapsule(myPayload, phoneDigits);
+            return createMyCapsule(myPayload);
           })()
         : isPrivateOnly
-        ? await createPrivateCapsule(privatePayload, {
-            phoneNum,
-            capsulePassword: capsulePassword || undefined,
-          })
+        ? await createPrivateCapsule(privatePayload)
         : await createPublicCapsule(publicPayload);
       const baseResult = {
         userName: senderName || data?.nickname || "",

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -336,44 +336,6 @@ export default function WriteForm() {
           </WriteDiv>
         )}
 
-        {isPrivateOnly && (
-          <WriteDiv title="전달 방법">
-            <div className="space-y-3">
-              <ActionTab
-                value={sendMethod}
-                onChange={setSendMethod}
-                tabs={[
-                  { id: "URL", tabName: "비밀번호" },
-                  { id: "PHONE", tabName: "전화번호" },
-                ]}
-              />
-              {sendMethod === "PHONE" ? (
-                <WriteDiv
-                  title="받는 사람 전화번호"
-                  warning="* 회원으로 등록된 전화번호만 사용할 수 있습니다."
-                >
-                  <WriteInput
-                    id="pagePw"
-                    type="text"
-                    placeholder="- 없이 입력"
-                  />
-                </WriteDiv>
-              ) : (
-                <WriteDiv
-                  title="편지 열람 비밀번호"
-                  warning="* 상대방이 해당 편지를 확인하기 위해 사용하는 비밀번호입니다."
-                >
-                  <WriteInput
-                    id="pagePw"
-                    type="password"
-                    placeholder="비밀번호를 입력하세요."
-                  />
-                </WriteDiv>
-              )}
-            </div>
-          </WriteDiv>
-        )}
-
         <WriteDiv
           title="편지 제목"
           warning="* 상대방이 편지를 열지 않아도 볼 수 있는 제목입니다. 공개를 원하지 않는 내용은 작성을 삼가 주세요."
@@ -412,6 +374,10 @@ export default function WriteForm() {
 
             <input type="hidden" name="content" value={content} />
           </div>
+        </WriteDiv>
+
+        <WriteDiv title="이미지 첨부 (선택사항)">
+          <div></div>
         </WriteDiv>
 
         <WriteDiv title="해제 조건">
@@ -481,9 +447,43 @@ export default function WriteForm() {
           </div>
         </WriteDiv>
 
-        <WriteDiv title="이미지 첨부 (선택사항)">
-          <div></div>
-        </WriteDiv>
+        {isPrivateOnly && (
+          <WriteDiv title="인증 방법">
+            <div className="space-y-3">
+              <ActionTab
+                value={sendMethod}
+                onChange={setSendMethod}
+                tabs={[
+                  { id: "URL", tabName: "비밀번호" },
+                  { id: "PHONE", tabName: "전화번호" },
+                ]}
+              />
+              {sendMethod === "PHONE" ? (
+                <WriteDiv
+                  title="받는 사람 전화번호"
+                  warning="* 회원으로 등록된 전화번호만 사용할 수 있습니다."
+                >
+                  <WriteInput
+                    id="pagePw"
+                    type="text"
+                    placeholder="- 없이 입력"
+                  />
+                </WriteDiv>
+              ) : (
+                <WriteDiv
+                  title="편지 열람 비밀번호"
+                  warning="* 상대방이 해당 편지를 확인하기 위해 사용하는 비밀번호입니다."
+                >
+                  <WriteInput
+                    id="pagePw"
+                    type="password"
+                    placeholder="비밀번호를 입력하세요."
+                  />
+                </WriteDiv>
+              )}
+            </div>
+          </WriteDiv>
+        )}
 
         <Button type="submit" className="w-full py-4 space-x-2">
           <Send />

--- a/src/components/capsule/new/left/WriteInput.tsx
+++ b/src/components/capsule/new/left/WriteInput.tsx
@@ -1,15 +1,19 @@
+import type { ChangeEventHandler } from "react";
+
 export default function WriteInput({
   id,
   type,
   placeholder,
   value,
   readOnly = false,
+  onChange,
 }: {
   id: string;
   type: string;
   placeholder: string;
   value?: string;
   readOnly?: boolean;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
 }) {
   return (
     <>
@@ -19,6 +23,7 @@ export default function WriteInput({
         type={type}
         placeholder={placeholder}
         value={value}
+        onChange={onChange}
         readOnly={readOnly}
         className="py-2.5 px-3 bg-sub-2 rounded-lg w-full outline-none border border-white focus:border focus:border-primary-2"
       />

--- a/src/components/capsule/new/modal/CopyTemplate.tsx
+++ b/src/components/capsule/new/modal/CopyTemplate.tsx
@@ -1,6 +1,20 @@
+import { useEffect } from "react";
 import Modal from "@/components/common/Modal";
 import Button from "@/components/common/Button";
 import { Check } from "lucide-react";
+
+async function copyWithClipboardAPI(text: string) {
+  if (!text.trim()) return;
+  try {
+    if (!navigator.clipboard || !window.isSecureContext) {
+      throw new Error("Clipboard API not available");
+    }
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    console.error("Clipboard copy failed", error);
+    alert("클립보드 복사에 실패했습니다. 브라우저 설정을 확인해 주세요.");
+  }
+}
 
 export default function CopyTemplate({
   open,
@@ -13,6 +27,31 @@ export default function CopyTemplate({
   onConfirm?: () => void;
   data: { userName: string; url: string; password?: string } | null;
 }) {
+  // 복사할 메시지
+  const shareText = `[Dear.___] 편지 전송 안내
+${
+  data?.userName ?? ""
+}님으로부터 편지가 도착했습니다. 아래의 링크를 통해 편지 세부 내용을 확인하실 수 있습니다.
+
+접속 URL: ${data?.url ?? ""}
+${data?.password ? `비밀번호: ${data.password}` : ""}
+
+※ 편지 내용을 저장하거나 보관함에 추가하시려면 로그인이 필요합니다.
+
+궁금한 점이 있으시면 Dear.___ 고객센터로 문의해주세요.
+감사합니다.`;
+
+  // Clipboard API 사용
+  const copyToClipboard = async () => {
+    await copyWithClipboardAPI(shareText);
+  };
+
+  useEffect(() => {
+    if (open && data?.userName) {
+      void copyWithClipboardAPI(shareText);
+    }
+  }, [open, data?.userName, data?.url, data?.password, shareText]);
+
   return (
     <Modal open={open} onClose={onClose}>
       <div className="w-full max-w-[520px] flex flex-col items-center gap-3 md:gap-5 rounded-2xl border-2 border-outline bg-white p-4 md:p-6">
@@ -28,17 +67,14 @@ export default function CopyTemplate({
         </div>
         <div className="border border-outline p-6 bg-sub rounded-xl">
           <pre className="text-text-4 text-sm md:text-base whitespace-pre-wrap break-keep">
-            {`[Dear.___] 편지 전송 안내 \n${
-              data?.userName
-            }님으로부터 편지가 도착했습니다. 아래의 링크를 통해 편지 세부 내용을 확인하실 수 있습니다.\n
-    접속 URL: ${data?.url}
-    ${
-      data?.password ? `비밀번호: ${data.password}` : ""
-    }\n\n※ 편지 내용을 저장하거나 보관함에 추가하시려면 로그인이 필요합니다.\n\n궁금한 점이 있으시면 Dear.___ 고객센터로 문의해주세요.\n감사합니다.`}
+            {shareText}
           </pre>
         </div>
         <div className="w-full flex gap-4">
-          <Button className="w-full py-1.5 md:py-3 text-text bg-white border-2 border-primary-3 text-sm md:text-base md:font-normal hover:text-white hover:border-primary-2">
+          <Button
+            className="w-full py-1.5 md:py-3 text-text bg-white border-2 border-primary-3 text-sm md:text-base md:font-normal hover:text-white hover:border-primary-2"
+            onClick={copyToClipboard}
+          >
             클립보드 복사
           </Button>
           <Button

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -1,4 +1,5 @@
 import { formatDate } from "@/lib/formatDate";
+
 type PreviewState = {
   title: string;
   senderName: string;
@@ -11,52 +12,56 @@ export default function Right({ preview }: { preview: PreviewState }) {
   const todayLabel = formatDate(new Date().toISOString());
 
   return (
-    <>
-      <section className="w-full h-full p-8">
-        <div className="h-full flex flex-col justify-between gap-6">
-          <div className="flex-1 flex flex-col gap-4">
-            <span className="text-xl">미리보기</span>
-            <div className=" w-full h-full p-8 rounded-2xl bg-[#F5F1E8] border border-outline space-y-6">
-              <div className="flex flex-col h-full justify-between">
-                <div className="text-2xl space-x-1">
-                  <p className="font-semibold">
-                    {title || "제목을 입력하세요"}
-                  </p>
+    <section className="w-full h-full p-8 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 flex flex-col gap-6">
+        {/* 위 영역 */}
+        <div className="flex-1 min-h-0 flex flex-col gap-4">
+          <span className="text-xl">미리보기</span>
 
-                  <span className="text-primary font-bold">Dear.</span>
+          <div className="flex-1 min-h-0 p-8 rounded-2xl bg-[#F5F1E8] border border-outline overflow-hidden">
+            <div className="h-full min-h-0 flex flex-col justify-between gap-6">
+              {/* 제목 + Dear */}
+              <div className="text-2xl space-x-1">
+                <p className="font-semibold">{title || "제목을 입력하세요"}</p>
+                <span className="text-primary font-bold">Dear.</span>
+                <span className="text-text-3">
+                  {senderName || "작성자 이름"}
+                </span>
+              </div>
+
+              {/* 편지 내용 */}
+              <div className="flex-1 min-h-0 overflow-y-auto">
+                <pre className="whitespace-pre-wrap wrap-break-word text-lg leading-7">
+                  {content || "편지 내용을 입력하세요"}
+                </pre>
+              </div>
+
+              {/* From */}
+              <div className="shrink-0 flex flex-col items-end gap-1">
+                <span className="text-text-3">{todayLabel}</span>
+                <p className="text-right text-2xl space-x-1">
+                  <span className="text-primary font-bold">From.</span>
                   <span className="text-text-3">
-                    {senderName || "작성자 이름"}
+                    {receiverName || "수신자 이름"}
                   </span>
-                </div>
-                <div className="flex-1 mx-1 overflow-hidden">
-                  <pre className="whitespace-pre-wrap wrap-break-word text-lg leading-7 overflow-y-auto overflow-x-hidden">
-                    {content || "편지 내용을 입력하세요"}
-                  </pre>
-                </div>
-                <div className="shrink-0 flex flex-col items-end gap-1">
-                  <span className="text-text-3">{todayLabel}</span>
-                  <p className="text-right text-2xl space-x-1">
-                    <span className="text-primary font-bold">From.</span>
-                    <span className="text-text-3">
-                      {receiverName || "수신자 이름"}
-                    </span>
-                  </p>
-                </div>
+                </p>
               </div>
             </div>
           </div>
-          <div className="w-full text-xs text-text-4 p-4 border border-outline rounded-xl bg-white/60">
-            <p>편지 정보</p>
-            <ul className="space-y-1">
-              <li>• 테마: (편지봉투 명) & (편지지 명)</li>
-              <li>• 공개 범위: 비공개</li>
-              <li>• 인증 방법: 비밀번호</li>
-              <li>• 해제 조건: 시간</li>
-              <li>• 글자 수: 0자</li>
-            </ul>
-          </div>
         </div>
-      </section>
-    </>
+
+        {/* 아래 */}
+        <div className="shrink-0 w-full text-xs text-text-4 p-4 border border-outline rounded-xl bg-white/60">
+          <p>편지 정보</p>
+          <ul className="space-y-1">
+            <li>• 테마: (편지봉투 명) & (편지지 명)</li>
+            <li>• 공개 범위: 비공개</li>
+            <li>• 인증 방법: 비밀번호</li>
+            <li>• 해제 조건: 시간</li>
+            <li>• 글자 수: 0자</li>
+          </ul>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -5,7 +5,7 @@ type PreviewState = {
   senderName: string;
   receiverName: string;
   content: string;
-  visibility: Visibility | "MYSELF";
+  visibility: Visibility | "SELF";
   authMethod: string;
   unlockType: string;
   charCount: number;
@@ -18,7 +18,7 @@ export default function Right({ preview }: { preview: PreviewState }) {
   const visibilityLabel =
     preview.visibility === "PUBLIC"
       ? "공개"
-      : preview.visibility === "MYSELF"
+      : preview.visibility === "SELF"
       ? "내게 쓰기"
       : "비공개";
   const authLabel =

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -1,12 +1,43 @@
-export default function Right() {
+import { formatDate } from "@/lib/formatDate";
+type PreviewState = {
+  title: string;
+  senderName: string;
+  receiverName: string;
+  content: string;
+};
+
+export default function Right({ preview }: { preview: PreviewState }) {
+  const { title, senderName, receiverName, content } = preview;
+  const todayLabel = formatDate(new Date().toISOString());
+
   return (
     <>
       <section className="w-full h-full p-8">
         <div className="h-full flex flex-col justify-between gap-6">
           <div className="flex-1 flex flex-col gap-4">
             <span className="text-xl">미리보기</span>
-            <div className=" w-full h-full p-8 rounded-2xl bg-[#F5F1E8] border border-outline">
-              {/* 여기에 편지 미리보기 작성 */}
+            <div className=" w-full h-full p-8 rounded-2xl bg-[#F5F1E8] border border-outline space-y-6">
+              <p className="font-semibold">{title || "제목을 입력하세요"}</p>
+              <div className="text-2xl space-x-1">
+                <span className="text-primary font-bold">Dear.</span>
+                <span className="text-text-3">
+                  {senderName || "작성자 이름"}
+                </span>
+              </div>
+              <div className="flex-1 mx-1 overflow-x-hidden overflow-y-auto">
+                <pre className="whitespace-pre-wrap wrap-break-word text-lg leading-7">
+                  {content || "편지 내용을 입력하세요"}
+                </pre>
+              </div>
+              <div className="shrink-0 flex flex-col items-end gap-1">
+                <span className="text-text-3">{todayLabel}</span>
+                <p className="text-right text-2xl space-x-1">
+                  <span className="text-primary font-bold">From.</span>
+                  <span className="text-text-3">
+                    {receiverName || "수신자 이름"}
+                  </span>
+                </p>
+              </div>
             </div>
           </div>
           <div className="w-full text-xs text-text-4 p-4 border border-outline rounded-xl bg-white/60">

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -5,11 +5,35 @@ type PreviewState = {
   senderName: string;
   receiverName: string;
   content: string;
+  visibility: Visibility | "MYSELF";
+  authMethod: string;
+  unlockType: string;
+  charCount: number;
 };
 
 export default function Right({ preview }: { preview: PreviewState }) {
   const { title, senderName, receiverName, content } = preview;
   const todayLabel = formatDate(new Date().toISOString());
+
+  const visibilityLabel =
+    preview.visibility === "PUBLIC"
+      ? "공개"
+      : preview.visibility === "MYSELF"
+      ? "내게 쓰기"
+      : "비공개";
+  const authLabel =
+    preview.authMethod === "NONE"
+      ? "인증 없음"
+      : preview.authMethod === "PHONE"
+      ? "전화번호"
+      : "비밀번호";
+  const unlockLabel =
+    preview.unlockType === "LOCATION"
+      ? "장소"
+      : preview.unlockType === "TIME_AND_LOCATION"
+      ? "시간 + 장소"
+      : "시간";
+  const charCountLabel = `${preview.charCount}자`;
 
   return (
     <section className="w-full h-full p-8 min-h-0 flex flex-col">
@@ -55,10 +79,10 @@ export default function Right({ preview }: { preview: PreviewState }) {
           <p>편지 정보</p>
           <ul className="space-y-1">
             <li>• 테마: (편지봉투 명) & (편지지 명)</li>
-            <li>• 공개 범위: 비공개</li>
-            <li>• 인증 방법: 비밀번호</li>
-            <li>• 해제 조건: 시간</li>
-            <li>• 글자 수: 0자</li>
+            <li>• 공개 범위: {visibilityLabel}</li>
+            <li>• 인증 방법: {authLabel}</li>
+            <li>• 해제 조건: {unlockLabel}</li>
+            <li>• 글자 수: {charCountLabel}</li>
           </ul>
         </div>
       </div>

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from "@/lib/formatDate";
+import { formatDate } from "@/lib/hooks/formatDate";
 
 type PreviewState = {
   title: string;

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -17,26 +17,31 @@ export default function Right({ preview }: { preview: PreviewState }) {
           <div className="flex-1 flex flex-col gap-4">
             <span className="text-xl">미리보기</span>
             <div className=" w-full h-full p-8 rounded-2xl bg-[#F5F1E8] border border-outline space-y-6">
-              <p className="font-semibold">{title || "제목을 입력하세요"}</p>
-              <div className="text-2xl space-x-1">
-                <span className="text-primary font-bold">Dear.</span>
-                <span className="text-text-3">
-                  {senderName || "작성자 이름"}
-                </span>
-              </div>
-              <div className="flex-1 mx-1 overflow-x-hidden overflow-y-auto">
-                <pre className="whitespace-pre-wrap wrap-break-word text-lg leading-7">
-                  {content || "편지 내용을 입력하세요"}
-                </pre>
-              </div>
-              <div className="shrink-0 flex flex-col items-end gap-1">
-                <span className="text-text-3">{todayLabel}</span>
-                <p className="text-right text-2xl space-x-1">
-                  <span className="text-primary font-bold">From.</span>
+              <div className="flex flex-col h-full justify-between">
+                <div className="text-2xl space-x-1">
+                  <p className="font-semibold">
+                    {title || "제목을 입력하세요"}
+                  </p>
+
+                  <span className="text-primary font-bold">Dear.</span>
                   <span className="text-text-3">
-                    {receiverName || "수신자 이름"}
+                    {senderName || "작성자 이름"}
                   </span>
-                </p>
+                </div>
+                <div className="flex-1 mx-1 overflow-hidden">
+                  <pre className="whitespace-pre-wrap wrap-break-word text-lg leading-7 overflow-y-auto overflow-x-hidden">
+                    {content || "편지 내용을 입력하세요"}
+                  </pre>
+                </div>
+                <div className="shrink-0 flex flex-col items-end gap-1">
+                  <span className="text-text-3">{todayLabel}</span>
+                  <p className="text-right text-2xl space-x-1">
+                    <span className="text-primary font-bold">From.</span>
+                    <span className="text-text-3">
+                      {receiverName || "수신자 이름"}
+                    </span>
+                  </p>
+                </div>
               </div>
             </div>
           </div>

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -11,13 +11,14 @@ type BuildCommonArgs = {
   memberId: number;
   senderName: string;
   receiverNickname?: string;
+  recipientPhone?: string | null;
   title: string;
   content: string;
   visibility: Visibility;
   effectiveUnlockType: UnlockType;
   dayForm: DayForm;
   locationForm: LocationForm;
-  capsulePassword?: string;
+  capsulePassword?: string | null;
   capsuleColor?: string;
   capsulePackingColor?: string;
 };
@@ -31,6 +32,8 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
   const {
     memberId,
     senderName,
+    recipientPhone = null,
+    capsulePassword = null,
     title,
     content,
     visibility,
@@ -49,6 +52,8 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
     memberId,
     nickname: senderName,
     receiverNickname: senderName,
+    recipientPhone,
+    capsulePassword,
     title,
     content,
     visibility,
@@ -93,6 +98,8 @@ export function buildPrivatePayload(
     memberId,
     senderName,
     receiverNickname = "",
+    recipientPhone = null,
+    capsulePassword = null,
     title,
     content,
     visibility,
@@ -110,15 +117,23 @@ export function buildPrivatePayload(
     memberId,
     nickname: senderName,
     receiverNickname,
+    recipientPhone,
+    capsulePassword,
     title,
     content,
     visibility,
     unlockType: effectiveUnlockType,
     unlockAt,
+    unlockUntil: undefined,
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.placeName
+        : "",
+    address:
+      effectiveUnlockType === "LOCATION" ||
+      effectiveUnlockType === "TIME_AND_LOCATION"
+        ? locationForm.address
         : "",
     locationLat:
       effectiveUnlockType === "LOCATION" ||
@@ -147,13 +162,13 @@ export function buildPublicPayload(
   const {
     memberId,
     senderName,
+    capsulePassword = null,
     title,
     content,
     visibility,
     effectiveUnlockType,
     dayForm,
     locationForm,
-    capsulePassword,
     capsuleColor = "",
     capsulePackingColor = "",
   } = args;
@@ -175,6 +190,12 @@ export function buildPublicPayload(
     visibility,
     unlockType: effectiveUnlockType,
     unlockAt,
+    unlockUntil: undefined,
+    address:
+      effectiveUnlockType === "LOCATION" ||
+      effectiveUnlockType === "TIME_AND_LOCATION"
+        ? locationForm.address
+        : "",
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
@@ -202,23 +223,11 @@ export function buildPublicPayload(
 /**
  * 비공개 캡슐 생성 API 호출
  * @param payload 빌드된 비공개 DTO
- * @param query   전화번호/비밀번호 전송 방식에 따른 쿼리 파라미터
  */
 export async function createPrivateCapsule(
-  payload: CreatePrivateCapsuleRequest,
-  query?: { phoneNum?: string; capsulePassword?: string }
+  payload: CreatePrivateCapsuleRequest
 ): Promise<CapsuleCreateResponse> {
-  const searchParams = new URLSearchParams();
-  if (query?.phoneNum) searchParams.set("phoneNum", query.phoneNum);
-  if (query?.capsulePassword)
-    searchParams.set("capsulePassword", query.capsulePassword);
-
-  const queryString = searchParams.toString();
-  const path = `/api/v1/capsule/create/private${
-    queryString ? `?${queryString}` : ""
-  }`;
-
-  return apiFetchRaw<CapsuleCreateResponse>(path, {
+  return apiFetchRaw<CapsuleCreateResponse>("/api/v1/capsule/create/private", {
     method: "POST",
     json: payload,
   });
@@ -240,18 +249,11 @@ export async function createPublicCapsule(
 /**
  * 내게쓰기 캡슐 생성 API 호출
  * @param payload 빌드된 내게쓰기 DTO
- * @param phone 로그인 사용자의 전화번호(숫자만)
  */
 export async function createMyCapsule(
-  payload: CreateMyCapsuleRequest,
-  phone: string
+  payload: CreateMyCapsuleRequest
 ): Promise<CapsuleCreateResponse> {
-  const searchParams = new URLSearchParams();
-  searchParams.set("phone", phone);
-
-  const path = `/api/v1/capsule/create/me?${searchParams.toString()}`;
-
-  return apiFetchRaw<CapsuleCreateResponse>(path, {
+  return apiFetchRaw<CapsuleCreateResponse>("/api/v1/capsule/create/me", {
     method: "POST",
     json: payload,
   });

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -32,8 +32,6 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
   const {
     memberId,
     senderName,
-    recipientPhone = null,
-    capsulePassword = null,
     title,
     content,
     visibility,
@@ -52,8 +50,6 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
     memberId,
     nickname: senderName,
     receiverNickname: senderName,
-    recipientPhone,
-    capsulePassword,
     title,
     content,
     visibility,

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -45,7 +45,7 @@ export function buildPrivatePayload(
 
   return {
     memberId,
-    nickName: senderName,
+    nickname: senderName,
     title,
     content,
     visibility,

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -10,6 +10,7 @@ import {
 type BuildCommonArgs = {
   memberId: number;
   senderName: string;
+  receiverNickname?: string;
   title: string;
   content: string;
   visibility: Visibility;
@@ -91,6 +92,7 @@ export function buildPrivatePayload(
   const {
     memberId,
     senderName,
+    receiverNickname = "",
     title,
     content,
     visibility,
@@ -107,6 +109,7 @@ export function buildPrivatePayload(
   return {
     memberId,
     nickname: senderName,
+    receiverNickname,
     title,
     content,
     visibility,

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -17,6 +17,26 @@ export interface CreatePrivateCapsuleRequest {
   maxViewCount: number;
 }
 
+export interface CreateMyCapsuleRequest {
+  memberId: number;
+  nickname: string;
+  receiverNickname: string;
+  title: string;
+  content: string;
+  visibility: Visibility;
+  unlockType: UnlockType;
+  unlockAt?: string;
+  unlockUntil?: string;
+  locationName: string;
+  address?: string;
+  locationLat: number;
+  locationLng: number;
+  viewingRadius: number;
+  packingColor: string;
+  contentColor: string;
+  maxViewCount: number;
+}
+
 export interface CreatePublicCapsuleRequest {
   memberId: number;
   nickname: string;
@@ -39,6 +59,7 @@ export interface CapsuleCreateResponse {
   memberId: number;
   capsuleId: number;
   nickname?: string;
+  receiverNickname?: string;
   title: string;
   content: string;
   visibility: string;

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -2,7 +2,7 @@ export type UnlockType = "TIME" | "LOCATION" | "TIME_AND_LOCATION";
 
 export interface CreatePrivateCapsuleRequest {
   memberId: number;
-  nickName: string;
+  nickname: string;
   title: string;
   content: string;
   visibility: Visibility;
@@ -38,7 +38,7 @@ export interface CreatePublicCapsuleRequest {
 export interface CapsuleCreateResponse {
   memberId: number;
   capsuleId: number;
-  nickName?: string;
+  nickname?: string;
   title: string;
   content: string;
   visibility: string;

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -26,8 +26,6 @@ export interface CreateMyCapsuleRequest {
   memberId: number;
   nickname: string;
   receiverNickname: string;
-  recipientPhone?: string | null;
-  capsulePassword?: string | null;
   title: string;
   content: string;
   visibility: Visibility;

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -4,12 +4,16 @@ export interface CreatePrivateCapsuleRequest {
   memberId: number;
   nickname: string;
   receiverNickname: string;
+  recipientPhone?: string | null;
+  capsulePassword?: string | null;
   title: string;
   content: string;
   visibility: Visibility;
   unlockType: UnlockType;
   unlockAt?: string;
+  unlockUntil?: string;
   locationName: string;
+  address?: string;
   locationLat: number;
   locationLng: number;
   viewingRadius: number;
@@ -22,6 +26,8 @@ export interface CreateMyCapsuleRequest {
   memberId: number;
   nickname: string;
   receiverNickname: string;
+  recipientPhone?: string | null;
+  capsulePassword?: string | null;
   title: string;
   content: string;
   visibility: Visibility;
@@ -49,7 +55,9 @@ export interface CreatePublicCapsuleRequest {
   visibility: Visibility;
   unlockType: UnlockType;
   unlockAt?: string;
+  unlockUntil?: string;
   locationName: string;
+  address?: string;
   locationLat: number;
   locationLng: number;
   locationRadiusM: number;

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -3,6 +3,7 @@ export type UnlockType = "TIME" | "LOCATION" | "TIME_AND_LOCATION";
 export interface CreatePrivateCapsuleRequest {
   memberId: number;
   nickname: string;
+  receiverNickname: string;
   title: string;
   content: string;
   visibility: Visibility;

--- a/src/type/newCapsule.d.ts
+++ b/src/type/newCapsule.d.ts
@@ -1,4 +1,4 @@
-type Visibility = "PRIVATE" | "PUBLIC";
+type Visibility = "PRIVATE" | "PUBLIC" | "MYSELF";
 
 type DayForm = {
   date: string; // "2025-12-12"

--- a/src/type/newCapsule.d.ts
+++ b/src/type/newCapsule.d.ts
@@ -1,4 +1,4 @@
-type Visibility = "PRIVATE" | "PUBLIC" | "MYSELF";
+type Visibility = "PRIVATE" | "PUBLIC" | "SELF";
 
 type DayForm = {
   date: string; // "2025-12-12"


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 캡슐 생성 DTO 변경(비공개/내게쓰기) 스펙 반영 및 폼 제출 로직 정리

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #46 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->
- [x] 비공개/내게쓰기 DTO를 신규 스펙에 맞춰 수정(전화번호/비밀번호 body 필드, 쿼리 제거)
- [x] 내게쓰기에서 서버가 토큰으로 전화번호를 인식한다는 전제에 맞춰 클라이언트 전송 값 정리
- [x] 생성 응답을 래핑({code,message,data})으로 처리(기존에는 평문으로 data만 받았음), URL/비밀번호 모달 표시 정상화
- [x] 내게쓰기 시 수신자 이름을 자동으로 발신자 이름으로 설정
- [x] 내게쓰기일 경우 visibility를 SELF로 전달하도록 수정 


## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->
- 공개 캡슐은 기존 로직 그대로이며 추가된 optional 필드가 전송되지 않도록 유지.

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
이제 내게쓰기는 전화번호를 넘겨주지 않습니다. 보안으로 인하여 백엔드에서 쿠키를 이용해서 처리하게 되었습니다!
```
3. **보안 강화**
    - 다른 사람에게 캡슐을 보내는 것이 원천 차단됩니다
    - 오직 본인에게만 캡슐을 보낼 수 있습니다
    ```
    
  쿼리로 비밀번호랑 전화번호 넘겨주던거 body필드에서 넘겨주게 변경되었습니다.
