### PR TITLE
[#34] feat(capsule): 편지지/편지봉투 색상 팔레트 구현

### DIFF
--- a/src/components/capsule/new/WritePage.tsx
+++ b/src/components/capsule/new/WritePage.tsx
@@ -15,6 +15,9 @@ export default function WritePage() {
     authMethod: "URL",
     unlockType: "TIME",
     charCount: 0,
+    envelopeColorName: "",
+    paperColorName: "",
+    paperColorHex: "#F5F1E8",
   });
 
   return (

--- a/src/components/capsule/new/left/Left.tsx
+++ b/src/components/capsule/new/left/Left.tsx
@@ -9,6 +9,9 @@ type PreviewState = {
   authMethod: string;
   unlockType: string;
   charCount: number;
+  envelopeColorName: string;
+  paperColorName: string;
+  paperColorHex: string;
 };
 
 export default function Left({

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -7,6 +7,7 @@ import {
   MapPin,
   PaintBucket,
   Send,
+  Check,
 } from "lucide-react";
 import WriteDiv from "./WriteDiv";
 import ActionTab from "./ActionTab";
@@ -85,6 +86,18 @@ export default function WriteForm({
   const [title, setTitle] = useState("");
   const [receiveName, setReceiveName] = useState("");
   const [content, setContent] = useState("");
+  const envelopeThemes = [
+    "#F5F1E8",
+    "#FBF2DE",
+    "#F7DADA",
+    "#DCECF7",
+    "#E8E0FF",
+    "#E6F8EB",
+    "#FAE2C9",
+  ];
+  const [selectedEnvelope, setSelectedEnvelope] = useState(0);
+  const paperThemes = envelopeThemes;
+  const [selectedPaper, setSelectedPaper] = useState(0);
 
   /* 한글 입력 중인지 체크 (조합 중엔 강제 slice 하면 입력이 깨질 수 있음) */
   const isComposingRef = useRef(false);
@@ -349,7 +362,7 @@ export default function WriteForm({
         </WriteDiv>
 
         <WriteDiv title="편지지 & 편지 봉투 테마">
-          <div>
+          <div className="space-y-4">
             <ActionTab
               value={paperTab}
               onChange={setPaperTab}
@@ -366,6 +379,57 @@ export default function WriteForm({
                 },
               ]}
             />
+            {paperTab === "ENVELOPE" ? (
+              <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
+                {envelopeThemes.map((color, idx) => (
+                  <button
+                    key={color + idx}
+                    type="button"
+                    onClick={() => setSelectedEnvelope(idx)}
+                    className={`relative h-30 rounded-2xl border transition ${
+                      selectedEnvelope === idx
+                        ? "border-primary shadow-[0_0_0_3px_rgba(255,87,34,0.15)]"
+                        : "border-outline"
+                    }`}
+                    style={{ backgroundColor: color }}
+                  >
+                    {selectedEnvelope === idx && (
+                      <span className="absolute top-3 left-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">
+                        <Check size={18} />
+                      </span>
+                    )}
+                  </button>
+                ))}
+                <div className="h-30 rounded-2xl border-2 border-dashed border-outline flex items-center justify-center text-text-3">
+                  업로드
+                </div>
+              </div>
+            ) : (
+              <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
+                {paperThemes.map((color, idx) => (
+                  <button
+                    key={color + idx}
+                    type="button"
+                    onClick={() => setSelectedPaper(idx)}
+                    className={`relative h-40 rounded-2xl border transition ${
+                      selectedPaper === idx
+                        ? "border-primary shadow-[0_0_0_3px_rgba(255,87,34,0.15)]"
+                        : "border-outline"
+                    }`}
+                    style={{ backgroundColor: color }}
+                  >
+                    {selectedPaper === idx && (
+                      <span className="absolute top-3 left-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">
+                        <Check size={18} />
+                      </span>
+                    )}
+                  </button>
+                ))}
+                <div className="h-40 rounded-2xl border-2 border-dashed border-outline flex items-center justify-center text-text-3">
+                  업로드
+                </div>
+              </div>
+            )}
           </div>
         </WriteDiv>
 

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -88,12 +88,12 @@ export default function WriteForm({
   const [content, setContent] = useState("");
   const envelopeThemes = [
     "#F5F1E8",
-    "#FBF2DE",
-    "#F7DADA",
-    "#DCECF7",
-    "#E8E0FF",
-    "#E6F8EB",
-    "#FAE2C9",
+    "#FEF7E7",
+    "#FCE8EC",
+    "#E8F4FC",
+    "#F0E8FC",
+    "#E8FCF4",
+    "#FFE8D6",
   ];
   const [selectedEnvelope, setSelectedEnvelope] = useState(0);
   const paperThemes = envelopeThemes;

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -9,6 +9,7 @@ import {
   Send,
   Check,
 } from "lucide-react";
+import { useMemo } from "react";
 import WriteDiv from "./WriteDiv";
 import ActionTab from "./ActionTab";
 import VisibilityOpt from "./VisibilityOpt";
@@ -45,6 +46,9 @@ type PreviewState = {
   authMethod: string;
   unlockType: string;
   charCount: number;
+  envelopeColorName: string;
+  paperColorName: string;
+  paperColorHex: string;
 };
 
 export default function WriteForm({
@@ -86,15 +90,18 @@ export default function WriteForm({
   const [title, setTitle] = useState("");
   const [receiveName, setReceiveName] = useState("");
   const [content, setContent] = useState("");
-  const envelopeThemes = [
-    "#F5F1E8",
-    "#FEF7E7",
-    "#FCE8EC",
-    "#E8F4FC",
-    "#F0E8FC",
-    "#E8FCF4",
-    "#FFE8D6",
-  ];
+  const envelopeThemes = useMemo(
+    () => [
+      { name: "BEIGE", color: "#F5F1E8" },
+      { name: "YELLOW", color: "#FEF7E7" },
+      { name: "PINK", color: "#FCE8EC" },
+      { name: "BLUE", color: "#E8F4FC" },
+      { name: "LAVENDER", color: "#F0E8FC" },
+      { name: "MINT", color: "#E8FCF4" },
+      { name: "PEACH", color: "#FFE8D6" },
+    ],
+    []
+  );
   const [selectedEnvelope, setSelectedEnvelope] = useState(0);
   const paperThemes = envelopeThemes;
   const [selectedPaper, setSelectedPaper] = useState(0);
@@ -133,6 +140,8 @@ export default function WriteForm({
         : unlockType === "MANUAL"
         ? "TIME_AND_LOCATION"
         : "TIME";
+    const envelopeSelected = envelopeThemes[selectedEnvelope];
+    const paperSelected = paperThemes[selectedPaper];
 
     // 내게쓰기일 경우 받는 사람 이름을 보내는 사람 이름으로 설정
     const receiverLabel = isSelf ? senderName : receiveName;
@@ -146,6 +155,9 @@ export default function WriteForm({
       authMethod: authMethodLabel,
       unlockType: unlockLabel,
       charCount: content.length,
+      envelopeColorName: envelopeSelected?.name ?? "",
+      paperColorName: paperSelected?.name ?? "",
+      paperColorHex: paperSelected?.color ?? "#F5F1E8",
     });
   }, [
     title,
@@ -156,6 +168,10 @@ export default function WriteForm({
     visibility,
     sendMethod,
     unlockType,
+    selectedEnvelope,
+    selectedPaper,
+    envelopeThemes,
+    paperThemes,
     onPreviewChange,
   ]);
 
@@ -273,6 +289,9 @@ export default function WriteForm({
       return;
     }
 
+    const envelopeSelected = envelopeThemes[selectedEnvelope];
+    const paperSelected = paperThemes[selectedPaper];
+
     const privatePayload = buildPrivatePayload({
       memberId: me.memberId,
       senderName,
@@ -285,6 +304,10 @@ export default function WriteForm({
       effectiveUnlockType,
       dayForm,
       locationForm,
+      packingColor: envelopeSelected?.name ?? "",
+      contentColor: paperSelected?.name ?? "",
+      capsuleColor: paperSelected?.name ?? "",
+      capsulePackingColor: envelopeSelected?.name ?? "",
     });
 
     const publicPayload = buildPublicPayload({
@@ -297,8 +320,10 @@ export default function WriteForm({
       dayForm,
       locationForm,
       capsulePassword,
-      capsuleColor: "",
-      capsulePackingColor: "",
+      capsuleColor: paperSelected?.name ?? "",
+      capsulePackingColor: envelopeSelected?.name ?? "",
+      packingColor: envelopeSelected?.name ?? "",
+      contentColor: paperSelected?.name ?? "",
     });
 
     try {
@@ -381,9 +406,9 @@ export default function WriteForm({
             />
             {paperTab === "ENVELOPE" ? (
               <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
-                {envelopeThemes.map((color, idx) => (
+                {envelopeThemes.map((item, idx) => (
                   <button
-                    key={color + idx}
+                    key={`${item.name}-${idx}`}
                     type="button"
                     onClick={() => setSelectedEnvelope(idx)}
                     className={`relative aspect-square rounded-2xl border-2 transition ${
@@ -391,7 +416,10 @@ export default function WriteForm({
                         ? "border-primary bg-primary/10"
                         : "border-outline"
                     }`}
-                    style={{ backgroundColor: color }}
+                    style={{
+                      backgroundColor:
+                        item.color as React.CSSProperties["backgroundColor"],
+                    }}
                   >
                     {selectedEnvelope === idx && (
                       <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">
@@ -406,9 +434,9 @@ export default function WriteForm({
               </div>
             ) : (
               <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
-                {paperThemes.map((color, idx) => (
+                {paperThemes.map((item, idx) => (
                   <button
-                    key={color + idx}
+                    key={`${item.name}-${idx}`}
                     type="button"
                     onClick={() => setSelectedPaper(idx)}
                     className={`relative aspect-square rounded-2xl border-2 transition ${
@@ -416,7 +444,10 @@ export default function WriteForm({
                         ? "border-primary bg-primary/10"
                         : "border-outline"
                     }`}
-                    style={{ backgroundColor: color }}
+                    style={{
+                      backgroundColor:
+                        item.color as React.CSSProperties["backgroundColor"],
+                    }}
                   >
                     {selectedPaper === idx && (
                       <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -374,7 +374,7 @@ export default function WriteForm({
                 },
                 {
                   id: "PAPER",
-                  tabName: "편지지(추가예정)",
+                  tabName: "편지지",
                   icon: <ImageIcon size={16} />,
                 },
               ]}
@@ -386,15 +386,15 @@ export default function WriteForm({
                     key={color + idx}
                     type="button"
                     onClick={() => setSelectedEnvelope(idx)}
-                    className={`relative aspect-square rounded-2xl border transition ${
+                    className={`relative aspect-square rounded-2xl border-2 transition ${
                       selectedEnvelope === idx
-                        ? "border-primary shadow-[0_0_0_3px_rgba(255,87,34,0.15)]"
+                        ? "border-primary bg-primary/10"
                         : "border-outline"
                     }`}
                     style={{ backgroundColor: color }}
                   >
                     {selectedEnvelope === idx && (
-                      <span className="absolute top-3 left-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">
+                      <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">
                         <Check size={18} />
                       </span>
                     )}
@@ -411,15 +411,15 @@ export default function WriteForm({
                     key={color + idx}
                     type="button"
                     onClick={() => setSelectedPaper(idx)}
-                    className={`relative aspect-square rounded-2xl border transition ${
+                    className={`relative aspect-square rounded-2xl border-2 transition ${
                       selectedPaper === idx
-                        ? "border-primary shadow-[0_0_0_3px_rgba(255,87,34,0.15)]"
+                        ? "border-primary bg-primary/10"
                         : "border-outline"
                     }`}
                     style={{ backgroundColor: color }}
                   >
                     {selectedPaper === idx && (
-                      <span className="absolute top-3 left-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">
+                      <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white shadow">
                         <Check size={18} />
                       </span>
                     )}

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -9,7 +9,10 @@ import {
   Send,
   Check,
 } from "lucide-react";
-import { useMemo } from "react";
+import {
+  CAPTURE_ENVELOPE_PALETTE,
+  type CapsuleColor,
+} from "@/constants/capsulePalette";
 import WriteDiv from "./WriteDiv";
 import ActionTab from "./ActionTab";
 import VisibilityOpt from "./VisibilityOpt";
@@ -90,18 +93,7 @@ export default function WriteForm({
   const [title, setTitle] = useState("");
   const [receiveName, setReceiveName] = useState("");
   const [content, setContent] = useState("");
-  const envelopeThemes = useMemo(
-    () => [
-      { name: "BEIGE", color: "#F5F1E8" },
-      { name: "YELLOW", color: "#FEF7E7" },
-      { name: "PINK", color: "#FCE8EC" },
-      { name: "BLUE", color: "#E8F4FC" },
-      { name: "LAVENDER", color: "#F0E8FC" },
-      { name: "MINT", color: "#E8FCF4" },
-      { name: "PEACH", color: "#FFE8D6" },
-    ],
-    []
-  );
+  const envelopeThemes = CAPTURE_ENVELOPE_PALETTE;
   const [selectedEnvelope, setSelectedEnvelope] = useState(0);
   const paperThemes = envelopeThemes;
   const [selectedPaper, setSelectedPaper] = useState(0);
@@ -406,7 +398,7 @@ export default function WriteForm({
             />
             {paperTab === "ENVELOPE" ? (
               <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
-                {envelopeThemes.map((item, idx) => (
+                {envelopeThemes.map((item: CapsuleColor, idx: number) => (
                   <button
                     key={`${item.name}-${idx}`}
                     type="button"
@@ -434,7 +426,7 @@ export default function WriteForm({
               </div>
             ) : (
               <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
-                {paperThemes.map((item, idx) => (
+                {paperThemes.map((item: CapsuleColor, idx: number) => (
                   <button
                     key={`${item.name}-${idx}`}
                     type="button"

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -386,7 +386,7 @@ export default function WriteForm({
                     key={color + idx}
                     type="button"
                     onClick={() => setSelectedEnvelope(idx)}
-                    className={`relative h-30 rounded-2xl border transition ${
+                    className={`relative aspect-square rounded-2xl border transition ${
                       selectedEnvelope === idx
                         ? "border-primary shadow-[0_0_0_3px_rgba(255,87,34,0.15)]"
                         : "border-outline"
@@ -400,7 +400,7 @@ export default function WriteForm({
                     )}
                   </button>
                 ))}
-                <div className="h-30 rounded-2xl border-2 border-dashed border-outline flex items-center justify-center text-text-3">
+                <div className="aspect-square rounded-2xl border-2 border-dashed border-outline flex items-center justify-center text-text-3">
                   업로드
                 </div>
               </div>
@@ -411,7 +411,7 @@ export default function WriteForm({
                     key={color + idx}
                     type="button"
                     onClick={() => setSelectedPaper(idx)}
-                    className={`relative h-40 rounded-2xl border transition ${
+                    className={`relative aspect-square rounded-2xl border transition ${
                       selectedPaper === idx
                         ? "border-primary shadow-[0_0_0_3px_rgba(255,87,34,0.15)]"
                         : "border-outline"
@@ -425,7 +425,7 @@ export default function WriteForm({
                     )}
                   </button>
                 ))}
-                <div className="h-40 rounded-2xl border-2 border-dashed border-outline flex items-center justify-center text-text-3">
+                <div className="aspect-square rounded-2xl border-2 border-dashed border-outline flex items-center justify-center text-text-3">
                   업로드
                 </div>
               </div>

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -44,12 +44,12 @@ export default function Right({ preview }: { preview: PreviewState }) {
 
           <div className="flex-1 min-h-0 p-8 rounded-2xl bg-[#F5F1E8] border border-outline overflow-hidden">
             <div className="h-full min-h-0 flex flex-col justify-between gap-6">
-              {/* 제목 + Dear */}
+              {/* 제목 + Dear (수신자) */}
               <div className="text-2xl space-x-1">
                 <p className="font-semibold">{title || "제목을 입력하세요"}</p>
                 <span className="text-primary font-bold">Dear.</span>
                 <span className="text-text-3">
-                  {senderName || "작성자 이름"}
+                  {receiverName || "수신자 이름"}
                 </span>
               </div>
 
@@ -60,13 +60,13 @@ export default function Right({ preview }: { preview: PreviewState }) {
                 </pre>
               </div>
 
-              {/* From */}
+              {/* From (발신자) */}
               <div className="shrink-0 flex flex-col items-end gap-1">
                 <span className="text-text-3">{todayLabel}</span>
                 <p className="text-right text-2xl space-x-1">
                   <span className="text-primary font-bold">From.</span>
                   <span className="text-text-3">
-                    {receiverName || "수신자 이름"}
+                    {senderName || "작성자 이름"}
                   </span>
                 </p>
               </div>

--- a/src/components/capsule/new/right/Right.tsx
+++ b/src/components/capsule/new/right/Right.tsx
@@ -9,6 +9,9 @@ type PreviewState = {
   authMethod: string;
   unlockType: string;
   charCount: number;
+  envelopeColorName: string;
+  paperColorName: string;
+  paperColorHex: string;
 };
 
 export default function Right({ preview }: { preview: PreviewState }) {
@@ -34,6 +37,10 @@ export default function Right({ preview }: { preview: PreviewState }) {
       ? "시간 + 장소"
       : "시간";
   const charCountLabel = `${preview.charCount}자`;
+  const paperColor = preview.paperColorHex || "#F5F1E8";
+  const themeLabel = `${preview.envelopeColorName || "-"} & ${
+    preview.paperColorName || "-"
+  }`;
 
   return (
     <section className="w-full h-full p-8 min-h-0 flex flex-col">
@@ -42,7 +49,10 @@ export default function Right({ preview }: { preview: PreviewState }) {
         <div className="flex-1 min-h-0 flex flex-col gap-4">
           <span className="text-xl">미리보기</span>
 
-          <div className="flex-1 min-h-0 p-8 rounded-2xl bg-[#F5F1E8] border border-outline overflow-hidden">
+          <div
+            className="flex-1 min-h-0 p-8 rounded-2xl border border-outline overflow-hidden"
+            style={{ backgroundColor: paperColor }}
+          >
             <div className="h-full min-h-0 flex flex-col justify-between gap-6">
               {/* 제목 + Dear (수신자) */}
               <div className="text-2xl space-x-1">
@@ -78,7 +88,7 @@ export default function Right({ preview }: { preview: PreviewState }) {
         <div className="shrink-0 w-full text-xs text-text-4 p-4 border border-outline rounded-xl bg-white/60">
           <p>편지 정보</p>
           <ul className="space-y-1">
-            <li>• 테마: (편지봉투 명) & (편지지 명)</li>
+            <li>• 테마: {themeLabel}</li>
             <li>• 공개 범위: {visibilityLabel}</li>
             <li>• 인증 방법: {authLabel}</li>
             <li>• 해제 조건: {unlockLabel}</li>

--- a/src/constants/capsulePalette.ts
+++ b/src/constants/capsulePalette.ts
@@ -1,0 +1,26 @@
+/**
+ * 캡슐 색상 팔레트 정의
+ * - 봉투/편지지 색상을 이름(name)과 HEX(color)로 관리합니다.
+ * - 사용 예시:
+ *   import { CAPTURE_ENVELOPE_PALETTE, CAPTURE_COLOR_MAP } from "@/constants/capsulePalette";
+ *   const hex = CAPTURE_COLOR_MAP["BEIGE"]; // "#F5F1E8"
+ *   const options = CAPTURE_ENVELOPE_PALETTE; // select 박스, 미리보기 등에 사용
+ */
+export type CapsuleColor = {
+  name: string;
+  color: string;
+};
+
+export const CAPTURE_ENVELOPE_PALETTE: CapsuleColor[] = [
+  { name: "BEIGE", color: "#F5F1E8" },
+  { name: "YELLOW", color: "#FEF7E7" },
+  { name: "PINK", color: "#FCE8EC" },
+  { name: "BLUE", color: "#E8F4FC" },
+  { name: "LAVENDER", color: "#F0E8FC" },
+  { name: "MINT", color: "#E8FCF4" },
+  { name: "PEACH", color: "#FFE8D6" },
+];
+
+export const CAPTURE_COLOR_MAP = Object.fromEntries(
+  CAPTURE_ENVELOPE_PALETTE.map((item) => [item.name, item.color])
+) as Record<string, string>;

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -21,6 +21,8 @@ type BuildCommonArgs = {
   capsulePassword?: string | null;
   capsuleColor?: string;
   capsulePackingColor?: string;
+  packingColor?: string;
+  contentColor?: string;
 };
 
 /**
@@ -77,8 +79,8 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
         ? locationForm.lng ?? 0
         : 0,
     viewingRadius: 0,
-    packingColor: "",
-    contentColor: "",
+    packingColor: args.packingColor ?? "",
+    contentColor: args.contentColor ?? "",
     maxViewCount: 0,
   };
 }
@@ -102,6 +104,8 @@ export function buildPrivatePayload(
     effectiveUnlockType,
     dayForm,
     locationForm,
+    packingColor = "",
+    contentColor = "",
   } = args;
   const unlockAt =
     effectiveUnlockType === "TIME" ||
@@ -142,8 +146,8 @@ export function buildPrivatePayload(
         ? locationForm.lng ?? 0
         : 0,
     viewingRadius: 0,
-    packingColor: "",
-    contentColor: "",
+    packingColor,
+    contentColor,
     maxViewCount: 0,
   };
 }
@@ -167,6 +171,8 @@ export function buildPublicPayload(
     locationForm,
     capsuleColor = "",
     capsulePackingColor = "",
+    packingColor = "",
+    contentColor = "",
   } = args;
 
   const unlockAt =
@@ -183,6 +189,8 @@ export function buildPublicPayload(
     capPassword: capsulePassword || undefined,
     capsuleColor,
     capsulePackingColor,
+    packingColor,
+    contentColor,
     visibility,
     unlockType: effectiveUnlockType,
     unlockAt,

--- a/src/lib/api/capsule/types.ts
+++ b/src/lib/api/capsule/types.ts
@@ -20,6 +20,8 @@ export interface CreatePrivateCapsuleRequest {
   packingColor: string;
   contentColor: string;
   maxViewCount: number;
+  capsuleColor?: string;
+  capsulePackingColor?: string;
 }
 
 export interface CreateMyCapsuleRequest {
@@ -50,6 +52,8 @@ export interface CreatePublicCapsuleRequest {
   capPassword?: string;
   capsuleColor: string;
   capsulePackingColor: string;
+  packingColor?: string;
+  contentColor?: string;
   visibility: Visibility;
   unlockType: UnlockType;
   unlockAt?: string;


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #34 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 캡슐 색상 팔레트 상수 분리(`capsulePalette`), 이름→HEX 매핑 제공
- [x] 봉투/편지지 선택 UI 퍼블리싱(그리드 팔레트)
- [x] 선택한 색상을 미리보기 배경/테마 라벨에 반영
- [x] 선택한 색상 이름을 API payload에 반영

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="1302" height="876" alt="image" src="https://github.com/user-attachments/assets/ccab1ac3-0d1e-4d70-a9d9-d8b2b5fe8b31" />
<img width="244" height="88" alt="image" src="https://github.com/user-attachments/assets/d1a16509-2aec-4a05-b026-7050ccff2d92" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
색상 팔레트를 src/constants/capsulePalette.ts 로 분리했습니다.
 `*   const hex = CAPTURE_COLOR_MAP["BEIGE"]; // "#F5F1E8"`
 처럼 사용할 수 있습니다.
 
보낸 편지 목록이나, 편지지 상세 보기에서 색상을 불러와야 할 경우,
"BEIGE" 이런식으로 색상을 받게 되어서 HEX값을 편하게 가져올 수 있습니다.