### PR TITLE
feat(map): 지도 페이지 추가 구현

### DIFF
--- a/src/components/dashboard/map/Card.tsx
+++ b/src/components/dashboard/map/Card.tsx
@@ -1,4 +1,4 @@
-import { MapPin } from "lucide-react";
+import { Heart, MapPin } from "lucide-react";
 type CardProps = {
   data: PublicCapsule;
   keyword: string;
@@ -26,16 +26,22 @@ export default function Card({ data, keyword }: CardProps) {
   }
   return (
     <>
-      <div className="border border-outline rounded-xl p-4 space-y-4 hover:bg-button-hover">
+      <div className="group border border-outline rounded-xl p-4 space-y-4 focus:bg-primary-3 group-focus:text-white">
         <div className="space-y-1">
-          <p>{highlightText(data.title, keyword)}</p>
-          <div className="text-xs flex items-center gap-1 text-text-3">
-            <div className="flex items-center gap-1">
+          <div className="flex justify-between group-focus:text-white">
+            <p>{highlightText(data.title, keyword)}</p>
+            <div className="flex items-center text-sm gap-1">
+              <Heart size={14}></Heart>
+              <p>0</p>
+            </div>
+          </div>
+          <div className="text-xs flex items-center gap-1 text-text-3 group-focus:text-white">
+            <div className="flex items-center gap-1 ">
               <MapPin size={12} />{" "}
               <span>{highlightText(data.capsuleLocationName, keyword)}</span>
             </div>
             <span>•</span>
-            <span className="text-primary-2">
+            <span className="text-primary-2 group-focus:text-white">
               {Math.floor(data.distanceToCapsule)}m
             </span>
           </div>
@@ -43,7 +49,7 @@ export default function Card({ data, keyword }: CardProps) {
         {/* <div className="text-sm">
           <p>벚꽃이 피는 이 거리에서 당신을 떠올립니다...</p>
         </div> */}
-        <div className="flex justify-between text-xs text-text-2">
+        <div className="flex justify-between text-xs text-text-2 group-focus:text-white">
           <span>from. {data.writerNickname}</span>{" "}
           <span>{data.capsuleCreatedAt.slice(0, 10)}</span>
         </div>

--- a/src/components/dashboard/map/FilterArea.tsx
+++ b/src/components/dashboard/map/FilterArea.tsx
@@ -1,10 +1,13 @@
 import FilterRow from "./FilterRow";
+import { AccessibleFilter } from "./MapContents";
 
 export default function FilterArea({
   radius,
   onRadiusChange,
   viewed,
   onViewedChange,
+  accessible,
+  onAccessibleChange,
   onReset,
   onClose,
 }: {
@@ -12,6 +15,8 @@ export default function FilterArea({
   onRadiusChange: (v: Radius) => void;
   viewed: ViewedFilter;
   onViewedChange: (v: ViewedFilter) => void;
+  accessible: AccessibleFilter;
+  onAccessibleChange: (v: AccessibleFilter) => void;
   onReset: () => void;
   onClose: () => void;
 }) {
@@ -64,6 +69,29 @@ export default function FilterArea({
             label="본 편지만"
             active={viewed === "READ"}
             onClick={() => onViewedChange("READ")}
+          />
+        </div>
+      </div>
+
+      {/* 조회 가능 여부 */}
+      <div className="space-y-2">
+        <p className="text-sm text-text-2">조회 가능 여부</p>
+
+        <div className="space-y-1">
+          <FilterRow
+            label="전체"
+            active={accessible === "ALL"}
+            onClick={() => onAccessibleChange("ALL")}
+          />
+          <FilterRow
+            label="열람 가능"
+            active={accessible === "ACCESSIBLE"}
+            onClick={() => onAccessibleChange("ACCESSIBLE")}
+          />
+          <FilterRow
+            label="열람 불가능"
+            active={accessible === "INACCESSIBLE"}
+            onClick={() => onAccessibleChange("INACCESSIBLE")}
           />
         </div>
       </div>

--- a/src/components/dashboard/map/MapContents.tsx
+++ b/src/components/dashboard/map/MapContents.tsx
@@ -9,6 +9,8 @@ import { fetchPublicCapsules } from "@/lib/api/dashboard/map";
 
 //서버 렌더링 방지
 import dynamic from "next/dynamic";
+import LetterDetailModal from "@/components/capsule/detail/LetterDetailModal";
+import { useSearchParams } from "next/navigation";
 const PublicCapsuleMap = dynamic(() => import("./PublicCapsuleMap"), {
   ssr: false,
 });
@@ -39,6 +41,8 @@ export default function MapContents() {
   const [error, setError] = useState<string | null>(null);
   //포커스 된 card
   const [focus, setFocus] = useState<{ id: number; ts: number } | null>(null);
+  const searchParams = useSearchParams();
+  const id = searchParams.get("id");
 
   //위치 정보 가져오기 실패했을 때 상황에 따른 에러 메세지
   const showErrorMsg = (error: GeolocationPositionError) => {
@@ -157,11 +161,17 @@ export default function MapContents() {
     } else return [];
   };
 
-  console.log(focus);
   const filteredData = filter(data);
 
   return (
     <div className="h-full flex flex-col gap-4">
+      {id ? (
+        <LetterDetailModal
+          capsuleId={Number(id)}
+          closeHref="/dashboard/map"
+          role="USER"
+        />
+      ) : null}
       {/* 헤더 */}
       <div className="space-y-2">
         <h3 className="text-3xl font-medium">
@@ -206,8 +216,9 @@ export default function MapContents() {
               location={mapLocation}
               data={filteredData}
               focus={focus?.id}
-              onClick={(id) => {
+              onClick={(id, lat, lng) => {
                 setFocus({ id, ts: Date.now() });
+                setMapLocation({ lat, lng });
               }}
             />
           ) : (

--- a/src/components/dashboard/map/MapContents.tsx
+++ b/src/components/dashboard/map/MapContents.tsx
@@ -214,6 +214,7 @@ export default function MapContents() {
           {mapLocation ? (
             <PublicCapsuleMap
               location={mapLocation}
+              myLocation={myLocation}
               data={filteredData}
               focus={focus?.id}
               onClick={(id, lat, lng) => {

--- a/src/components/dashboard/map/MapList.tsx
+++ b/src/components/dashboard/map/MapList.tsx
@@ -6,7 +6,7 @@ import { Search } from "lucide-react";
 
 type MapListProps = {
   listData?: PublicCapsule[];
-  onClick: (lat: number, lng: number) => void;
+  onClick: (id: number, lat: number, lng: number) => void;
   focus: { id: number; ts: number } | null;
 };
 
@@ -67,8 +67,10 @@ export default function MapList({ listData, onClick, focus }: MapListProps) {
             <button
               key={d.capsuleId}
               type="button"
-              className="w-full text-left focus:bg-button-hover"
-              onClick={() => onClick(d.capsuleLatitude, d.capsuleLongitude)}
+              className="group w-full text-left rounded-xl hover:bg-button-hover focus:bg-primary-2"
+              onClick={() =>
+                onClick(d.capsuleId, d.capsuleLatitude, d.capsuleLongitude)
+              }
               ref={(val) => {
                 cardFocus.current[d.capsuleId] = val;
               }}

--- a/src/components/dashboard/map/PublicCapsuleMap.tsx
+++ b/src/components/dashboard/map/PublicCapsuleMap.tsx
@@ -6,22 +6,28 @@ import { CustomOverlayMap, Map, MarkerClusterer } from "react-kakao-maps-sdk";
 
 const onClusterclick = () => {};
 
-//마커 컨테이너
+//마커 생성
 const EventMarkerContainer = ({
   position,
   content,
   onClick,
+  isFocus,
 }: {
   position: { lat: number; lng: number };
   content: string;
   onClick: () => void;
+  isFocus: boolean;
 }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   return (
-    <CustomOverlayMap position={position} yAnchor={0}>
+    <CustomOverlayMap
+      position={position}
+      yAnchor={0}
+      zIndex={isFocus ? 999 : 1}
+    >
       <div
-        className="relative flex flex-col items-center"
+        className={`relative flex flex-col items-center`}
         onMouseEnter={() => setIsVisible(true)}
         onMouseLeave={() => setIsVisible(false)}
         onClick={onClick}
@@ -42,7 +48,9 @@ const EventMarkerContainer = ({
           {content}
         </div>
         <div
-          className="flex items-center justify-center w-11 h-11 rounded-full bg-primary-2"
+          className={`flex items-center justify-center w-11 h-11 rounded-full ${
+            isFocus ? "bg-primary scale-[1.2]" : "bg-primary-2"
+          }`}
           onClick={onClick}
         >
           <MapPin color="white"></MapPin>
@@ -58,12 +66,15 @@ type PublicCapsuleMapProps = {
     lng: number;
   };
   data: PublicCapsule[];
+  focus?: number;
   onClick: (id: number) => void;
 };
+
 export default function PublicCapsuleMap({
   location,
   data,
   onClick,
+  focus,
 }: PublicCapsuleMapProps) {
   const mapRef = useRef<kakao.maps.Map | null>(null);
 
@@ -80,7 +91,7 @@ export default function PublicCapsuleMap({
       <Map
         center={location} //중심 좌표
         level={6} //줌 레벨
-        isPanto={false} //부드럽게 이동
+        isPanto={true} //부드럽게 이동
         style={{ width: "100%", height: "100%", borderRadius: "12px" }}
         //생성 시 해당 지도 객체를 저장
         onCreate={(map) => {
@@ -89,7 +100,7 @@ export default function PublicCapsuleMap({
       >
         <MarkerClusterer
           averageCenter={true} // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
-          minLevel={1} // 클러스터 할 최소 지도 레벨
+          minLevel={2} // 클러스터 할 최소 지도 레벨
           styles={[
             {
               // 1~9개
@@ -101,26 +112,26 @@ export default function PublicCapsuleMap({
               borderRadius: "50%",
               lineHeight: "48px",
             },
-            {
-              // 10~99개
-              width: "48px",
-              height: "48px",
-              background: "#FF583B",
-              textAlign: "center",
-              color: "#fff",
-              borderRadius: "50%",
-              lineHeight: "48px",
-            },
-            {
-              // 100개 이상
-              width: "48px",
-              height: "48px",
-              background: "#FF583B",
-              textAlign: "center",
-              color: "#fff",
-              borderRadius: "50%",
-              lineHeight: "48px",
-            },
+            // {
+            //   // 10~99개
+            //   width: "48px",
+            //   height: "48px",
+            //   background: "#FF583B",
+            //   textAlign: "center",
+            //   color: "#fff",
+            //   borderRadius: "50%",
+            //   lineHeight: "48px",
+            // },
+            // {
+            //   // 100개 이상
+            //   width: "48px",
+            //   height: "48px",
+            //   background: "#FF583B",
+            //   textAlign: "center",
+            //   color: "#fff",
+            //   borderRadius: "50%",
+            //   lineHeight: "48px",
+            // },
           ]}
           onClusterclick={onClusterclick}
         >
@@ -133,6 +144,7 @@ export default function PublicCapsuleMap({
               }}
               content={d.title}
               onClick={() => onClick(d.capsuleId)}
+              isFocus={!!(d.capsuleId === focus)}
             />
           ))}
         </MarkerClusterer>

--- a/src/components/dashboard/map/PublicCapsuleMap.tsx
+++ b/src/components/dashboard/map/PublicCapsuleMap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MapPin } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { CustomOverlayMap, Map, MarkerClusterer } from "react-kakao-maps-sdk";
 
@@ -12,11 +13,13 @@ const EventMarkerContainer = ({
   content,
   onClick,
   isFocus,
+  showCapsule,
 }: {
   position: { lat: number; lng: number };
   content: string;
   onClick: () => void;
   isFocus: boolean;
+  showCapsule: () => void;
 }) => {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -44,6 +47,7 @@ const EventMarkerContainer = ({
                 : "opacity-0 pointer-none"
             }
           `}
+          onClick={showCapsule}
         >
           {content}
         </div>
@@ -67,17 +71,18 @@ type PublicCapsuleMapProps = {
   };
   data: PublicCapsule[];
   focus?: number;
-  onClick: (id: number) => void;
+  onClick: (id: number, lat: number, lng: number) => void;
 };
 
 export default function PublicCapsuleMap({
   location,
   data,
   onClick,
+
   focus,
 }: PublicCapsuleMapProps) {
   const mapRef = useRef<kakao.maps.Map | null>(null);
-
+  const router = useRouter();
   //props로 받은 location 위치가 바뀌면 지도 센터 좌표 변경
   useEffect(() => {
     //지도가 아직 안그려진 상태면 return
@@ -143,8 +148,13 @@ export default function PublicCapsuleMap({
                 lng: d.capsuleLongitude,
               }}
               content={d.title}
-              onClick={() => onClick(d.capsuleId)}
+              onClick={() =>
+                onClick(d.capsuleId, d.capsuleLatitude, d.capsuleLongitude)
+              }
               isFocus={!!(d.capsuleId === focus)}
+              showCapsule={() => {
+                router.push(`/dashboard/map?id=${d.capsuleId}`);
+              }}
             />
           ))}
         </MarkerClusterer>


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

지도 페이지 추가 구현

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 선택된 마커 크기 키우기, 색 진하게(primary), 마커 위치로 맵 center 이동, 맨 위로 렌더링
- [x] 선택된 card 색 진하게
- [x] 마커 hover시 바로 위에 캡슐 세부 열람할 수 있는 버튼 띄우기

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="1633" height="864" alt="스크린샷 2025-12-21 오전 2 16 11" src="https://github.com/user-attachments/assets/a544df68-21fe-4911-bba4-fd85932e250b" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- 열람 가능 여부 필터링은 API response 변경 요청한 사항 현재(12/21 02:19) 갱신이 되지 않은 것으로 확인되어 추후에 다시 PR할 계획입니다.
- 마커가 겹쳤을 때의 처리는 zIndex 속성으로 해결해서 일단은 Card에 캡슐 세부 열람 버튼을 넣지않고 figma 디자인대로 진행했습니다.
- 장소, 제목 검색은 현재 혼합되어 나오고 있습니다. 이에 대한 의견이 필요합니다.
버튼을 두어 검색을 따로 할지, 혼합되어 보여지나 제목, 장소 순으로 정렬하여 보여줄지(좀 귀찮을듯...), 장소 검색을 아예 빼버릴지 고민이 됩니다... 
