### PR TITLE
[#41] feat(capsule): 공간 조건 캡슐 생성 구현

### DIFF
--- a/src/app/(user)/capsules/new/layout.tsx
+++ b/src/app/(user)/capsules/new/layout.tsx
@@ -1,0 +1,19 @@
+import { authApiServer } from "@/lib/api/auth/auth.server";
+import { redirect } from "next/navigation";
+
+export default async function CapsulesNewLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  let me;
+  try {
+    me = await authApiServer.me();
+  } catch {
+    redirect("/auth/login");
+  }
+
+  if (me.role !== "USER") redirect("/auth/login");
+
+  return <>{children}</>;
+}

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -83,6 +83,7 @@ export default function WriteForm({
     query: "",
     placeName: "",
     locationLabel: "",
+    viewingRadius: 100,
     address: "",
     lat: undefined,
     lng: undefined,
@@ -279,9 +280,10 @@ export default function WriteForm({
       (!locationForm.placeName ||
         !locationForm.lat ||
         !locationForm.lng ||
-        !locationForm.locationLabel?.trim())
+        !locationForm.locationLabel?.trim() ||
+        !locationForm.viewingRadius)
     ) {
-      window.alert("장소를 선택하고, 장소 이름을 입력해 주세요.");
+      window.alert("장소를 선택하고, 장소 이름과 조회반경을 입력해 주세요.");
       return;
     }
 

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -82,6 +82,7 @@ export default function WriteForm({
   const [locationForm, setLocationForm] = useState<LocationForm>({
     query: "",
     placeName: "",
+    locationLabel: "",
     address: "",
     lat: undefined,
     lng: undefined,
@@ -275,9 +276,12 @@ export default function WriteForm({
     if (
       (effectiveUnlockType === "LOCATION" ||
         effectiveUnlockType === "TIME_AND_LOCATION") &&
-      (!locationForm.placeName || !locationForm.lat || !locationForm.lng)
+      (!locationForm.placeName ||
+        !locationForm.lat ||
+        !locationForm.lng ||
+        !locationForm.locationLabel?.trim())
     ) {
-      window.alert("장소를 선택해 주세요.");
+      window.alert("장소를 선택하고, 장소 이름을 입력해 주세요.");
       return;
     }
 

--- a/src/components/capsule/new/left/unlockOpt/KakaoLocation.tsx
+++ b/src/components/capsule/new/left/unlockOpt/KakaoLocation.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Map, MapMarker } from "react-kakao-maps-sdk";
+
+type PickedLocation = {
+  lat: number;
+  lng: number;
+  placeName: string;
+  address?: string;
+};
+
+type KakaoLocationProps = {
+  query: string;
+  searchSignal: number;
+  value?: Partial<LocationForm>;
+  onPick: (picked: PickedLocation) => void;
+};
+
+type KakaoPlaceItem = {
+  id: string;
+  place_name: string;
+  x: string; // lng
+  y: string; // lat
+  address_name?: string;
+  road_address_name?: string;
+};
+
+function useKakaoReady() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: number | null = null;
+    const startedAt = Date.now();
+
+    const tryLoad = () => {
+      const kakao = (window as any)?.kakao;
+      if (!kakao?.maps) return false;
+
+      // autoload=false 환경 대응
+      if (typeof kakao.maps.load === "function") {
+        kakao.maps.load(() => {
+          if (cancelled) return;
+          setReady(true);
+        });
+        return true;
+      }
+
+      setReady(true);
+      return true;
+    };
+
+    if (tryLoad()) return;
+
+    intervalId = window.setInterval(() => {
+      const ok = tryLoad();
+      const timeout = Date.now() - startedAt > 6000;
+      if (ok || timeout) {
+        if (intervalId) window.clearInterval(intervalId);
+      }
+    }, 100);
+
+    return () => {
+      cancelled = true;
+      if (intervalId) window.clearInterval(intervalId);
+    };
+  }, []);
+
+  return ready;
+}
+
+export default function KakaoLocation({
+  query,
+  searchSignal,
+  value,
+  onPick,
+}: KakaoLocationProps) {
+  const ready = useKakaoReady();
+
+  const initialCenter = useMemo(() => {
+    if (typeof value?.lat === "number" && typeof value?.lng === "number") {
+      return { lat: value.lat, lng: value.lng };
+    }
+    // 기본: 서울 시청 근처
+    return { lat: 37.5665, lng: 126.978 };
+  }, [value?.lat, value?.lng]);
+
+  const [center, setCenter] = useState<{ lat: number; lng: number }>(
+    initialCenter
+  );
+  const [marker, setMarker] = useState<{ lat: number; lng: number } | null>(
+    () =>
+      typeof value?.lat === "number" && typeof value?.lng === "number"
+        ? { lat: value.lat, lng: value.lng }
+        : null
+  );
+
+  const [results, setResults] = useState<KakaoPlaceItem[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const placesRef = useRef<any>(null);
+  const geocoderRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (!ready) return;
+    const kakao = (window as any)?.kakao;
+    if (!kakao?.maps?.services) return;
+
+    if (!placesRef.current) {
+      placesRef.current = new kakao.maps.services.Places();
+    }
+    if (!geocoderRef.current) {
+      geocoderRef.current = new kakao.maps.services.Geocoder();
+    }
+  }, [ready]);
+
+  // 외부 value(lat/lng)가 바뀌면 지도도 동기화
+  useEffect(() => {
+    if (typeof value?.lat !== "number" || typeof value?.lng !== "number")
+      return;
+    setCenter({ lat: value.lat, lng: value.lng });
+    setMarker({ lat: value.lat, lng: value.lng });
+  }, [value?.lat, value?.lng]);
+
+  const reverseGeocode = (lat: number, lng: number) => {
+    const kakao = (window as any)?.kakao;
+    const geocoder = geocoderRef.current;
+    if (!kakao?.maps?.services || !geocoder)
+      return Promise.resolve<string | undefined>(undefined);
+
+    return new Promise<string | undefined>((resolve) => {
+      // coord2Address: (lng, lat) 순서 주의
+      geocoder.coord2Address(lng, lat, (result: any, status: any) => {
+        if (status !== kakao.maps.services.Status.OK) {
+          resolve(undefined);
+          return;
+        }
+        const addr =
+          result?.[0]?.road_address?.address_name ??
+          result?.[0]?.address?.address_name;
+        resolve(addr);
+      });
+    });
+  };
+
+  const handlePick = async (picked: PickedLocation) => {
+    setCenter({ lat: picked.lat, lng: picked.lng });
+    setMarker({ lat: picked.lat, lng: picked.lng });
+    onPick(picked);
+  };
+
+  // 검색 트리거 (Location.tsx에서 버튼/엔터로 searchSignal 증가)
+  // 결과 클릭 시 x/y를 lng/lat로 변환해서 onPick
+  useEffect(() => {
+    if (!ready) return;
+    const kakao = (window as any)?.kakao;
+    const places = placesRef.current;
+
+    const q = query?.trim() ?? "";
+    if (!q) {
+      setResults([]);
+      setError(null);
+      return;
+    }
+    if (!kakao?.maps?.services || !places) {
+      setError("카카오 지도 서비스를 불러오지 못했습니다.");
+      return;
+    }
+
+    setIsSearching(true);
+    setError(null);
+
+    places.keywordSearch(q, (data: KakaoPlaceItem[], status: any) => {
+      setIsSearching(false);
+      if (status !== kakao.maps.services.Status.OK) {
+        setResults([]);
+        setError("검색 결과가 없어요. 다른 키워드로 시도해 주세요.");
+        return;
+      }
+      setResults(data ?? []);
+      setError(null);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchSignal, ready]);
+
+  return (
+    <div className="space-y-2">
+      <div className="h-40 rounded-lg bg-sub-2 overflow-hidden">
+        {ready ? (
+          <Map
+            center={center}
+            level={5}
+            style={{ width: "100%", height: "100%" }}
+            // 클릭한 위치 좌표 가져오기
+            onClick={async (_map, mouseEvent) => {
+              const lat = mouseEvent.latLng.getLat();
+              const lng = mouseEvent.latLng.getLng();
+
+              setCenter({ lat, lng });
+              setMarker({ lat, lng });
+
+              const address = await reverseGeocode(lat, lng);
+              const placeName = address ?? "지도에서 선택한 위치";
+
+              await handlePick({ lat, lng, placeName, address });
+            }}
+          >
+            {marker ? <MapMarker position={marker} /> : null}
+          </Map>
+        ) : (
+          <div className="h-full flex items-center justify-center text-xs text-text-5">
+            지도를 불러오는 중...
+          </div>
+        )}
+      </div>
+
+      <div className="text-xs text-text-3">
+        지도에서 클릭하거나, 검색 결과에서 장소를 선택해 주세요.
+      </div>
+
+      {isSearching ? (
+        <div className="text-xs text-text-4">검색 중...</div>
+      ) : null}
+      {error ? <div className="text-xs text-red-500">{error}</div> : null}
+
+      {results.length ? (
+        <div className="max-h-44 overflow-auto rounded-lg border border-outline bg-white">
+          {results.map((item) => {
+            const address = item.road_address_name || item.address_name || "";
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className="w-full text-left px-3 py-2 hover:bg-sub-2 border-b border-outline last:border-b-0"
+                onClick={() => {
+                  const lat = Number(item.y);
+                  const lng = Number(item.x);
+                  handlePick({
+                    lat,
+                    lng,
+                    placeName: item.place_name,
+                    address,
+                  });
+                }}
+              >
+                <div className="text-sm text-text-2">{item.place_name}</div>
+                {address ? (
+                  <div className="text-xs text-text-4 mt-0.5">{address}</div>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/capsule/new/left/unlockOpt/KakaoLocation.tsx
+++ b/src/components/capsule/new/left/unlockOpt/KakaoLocation.tsx
@@ -2,8 +2,17 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Map, MapMarker } from "react-kakao-maps-sdk";
+import {
+  type KakaoGeocoderService,
+  type KakaoNamespace,
+  type KakaoPlaceItem,
+  type KakaoPlacesService,
+} from "@/lib/kakao/types";
 
-type KakaoStatus = string;
+function getKakao(): KakaoNamespace | null {
+  const kakao = (window as unknown as { kakao?: KakaoNamespace })?.kakao;
+  return kakao ?? null;
+}
 
 type PickedLocation = {
   lat: number;
@@ -18,51 +27,6 @@ type KakaoLocationProps = {
   value?: Partial<LocationForm>;
   onPick: (picked: PickedLocation) => void;
 };
-
-type KakaoPlaceItem = {
-  id: string;
-  place_name: string;
-  x: string; // lng
-  y: string; // lat
-  address_name?: string;
-  road_address_name?: string;
-};
-
-type KakaoCoord2AddressResult = Array<{
-  road_address?: { address_name?: string };
-  address?: { address_name?: string };
-}>;
-
-type KakaoPlacesService = {
-  keywordSearch: (
-    query: string,
-    callback: (data: KakaoPlaceItem[], status: KakaoStatus) => void
-  ) => void;
-};
-
-type KakaoGeocoderService = {
-  coord2Address: (
-    lng: number,
-    lat: number,
-    callback: (result: KakaoCoord2AddressResult, status: KakaoStatus) => void
-  ) => void;
-};
-
-type KakaoNamespace = {
-  maps?: {
-    load?: (callback: () => void) => void;
-    services?: {
-      Places: new () => KakaoPlacesService;
-      Geocoder: new () => KakaoGeocoderService;
-      Status: { OK: KakaoStatus };
-    };
-  };
-};
-
-function getKakao(): KakaoNamespace | null {
-  const kakao = (window as unknown as { kakao?: KakaoNamespace })?.kakao;
-  return kakao ?? null;
-}
 
 function useKakaoReady() {
   const [ready, setReady] = useState(false);

--- a/src/components/capsule/new/left/unlockOpt/Location.tsx
+++ b/src/components/capsule/new/left/unlockOpt/Location.tsx
@@ -59,28 +59,9 @@ export default function Location({
         </div>
       </div>
 
-      {/* 선택된 장소 표시 */}
+      {/* 선택 정보 표시 */}
       <div className="text-xs text-text-3">
-        {value.placeName ? (
-          <>
-            선택된 장소: <span className="text-text-2">{value.placeName}</span>
-          </>
-        ) : (
-          "아직 선택된 장소가 없어요."
-        )}
-        {value.address ? (
-          <div className="mt-1">
-            주소: <span className="text-text-2">{value.address}</span>
-          </div>
-        ) : null}
-        {typeof value.lat === "number" && typeof value.lng === "number" ? (
-          <div className="mt-1">
-            좌표:{" "}
-            <span className="text-text-2">
-              {value.lat.toFixed(6)}, {value.lng.toFixed(6)}
-            </span>
-          </div>
-        ) : null}
+        {!value.placeName ? "아직 선택된 장소가 없어요." : null}
       </div>
 
       <KakaoLocation
@@ -88,16 +69,40 @@ export default function Location({
         value={value}
         searchSignal={searchSignal}
         onPick={(picked) => {
+          // 사용자가 별칭을 입력했다면 별칭을 자동으로 채우지 않음
+          const prevLabel = value.locationLabel?.trim() ?? "";
+          const shouldAutoFillLabel =
+            !prevLabel || prevLabel === (value.placeName ?? "");
+
           onChange({
             ...value,
             query: picked.placeName || value.query,
             placeName: picked.placeName,
+            locationLabel: shouldAutoFillLabel
+              ? picked.placeName
+              : value.locationLabel,
             address: picked.address,
             lat: picked.lat,
             lng: picked.lng,
           });
         }}
       />
+
+      {/* 사용자 지정 이름 */}
+      <div className="flex flex-col space-y-2">
+        <label htmlFor="locationLabel">이 장소를 뭐라고 부를까요?</label>
+        <input
+          type="text"
+          name="locationLabel"
+          id="locationLabel"
+          value={value.locationLabel}
+          onChange={(e) =>
+            onChange({ ...value, locationLabel: e.target.value })
+          }
+          placeholder="예) 우리가 처음 만난 카페, 약속 장소"
+          className="w-full bg-sub-2 rounded-lg text-sm p-2 outline-none border border-white/0 focus:border-primary-2"
+        />
+      </div>
     </>
   );
 }

--- a/src/components/capsule/new/left/unlockOpt/Location.tsx
+++ b/src/components/capsule/new/left/unlockOpt/Location.tsx
@@ -4,6 +4,9 @@ import { MapPin } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import KakaoLocation from "./KakaoLocation";
 
+// 조회 반경
+const VIEWING_RADIUS_OPTIONS = [50, 100, 300, 500, 1000] as const;
+
 export default function Location({
   value,
   onChange,
@@ -87,6 +90,31 @@ export default function Location({
           });
         }}
       />
+
+      {/* 조회 반경 */}
+      <div className="flex flex-col space-y-2">
+        <span className="text-sm">조회 반경 (m)</span>
+        <div className="flex flex-wrap gap-2">
+          {VIEWING_RADIUS_OPTIONS.map((r) => {
+            const selected = value.viewingRadius === r;
+            return (
+              <button
+                key={r}
+                type="button"
+                onClick={() => onChange({ ...value, viewingRadius: r })}
+                className={[
+                  "flex-1 basis-0 min-w-[72px] px-3 py-2 rounded-lg text-sm border-2 transition text-center bg-white",
+                  selected
+                    ? "text-text-2 border-primary"
+                    : "text-text-2 border-outline hover:border-primary/50",
+                ].join(" ")}
+              >
+                {r}
+              </button>
+            );
+          })}
+        </div>
+      </div>
 
       {/* 사용자 지정 이름 */}
       <div className="flex flex-col space-y-2">

--- a/src/components/capsule/new/left/unlockOpt/Location.tsx
+++ b/src/components/capsule/new/left/unlockOpt/Location.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { MapPin } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
-import KakaoLocation from "./KakaoLocation";
+import { useCallback, useMemo, useRef } from "react";
+import KakaoLocation, { type KakaoLocationHandle } from "./KakaoLocation";
 
 // 조회 반경
 const VIEWING_RADIUS_OPTIONS = [50, 100, 300, 500, 1000] as const;
@@ -14,13 +14,13 @@ export default function Location({
   value: LocationForm;
   onChange: (v: LocationForm) => void;
 }) {
-  const [searchSignal, setSearchSignal] = useState(0);
+  const kakaoLocationRef = useRef<KakaoLocationHandle | null>(null);
 
   const canSearch = useMemo(() => Boolean(value.query?.trim()), [value.query]);
 
   const triggerSearch = useCallback(() => {
     if (!canSearch) return;
-    setSearchSignal((prev) => prev + 1);
+    kakaoLocationRef.current?.search();
   }, [canSearch]);
 
   return (
@@ -70,7 +70,7 @@ export default function Location({
       <KakaoLocation
         query={value.query}
         value={value}
-        searchSignal={searchSignal}
+        ref={kakaoLocationRef}
         onPick={(picked) => {
           // 사용자가 별칭을 입력했다면 별칭을 자동으로 채우지 않음
           const prevLabel = value.locationLabel?.trim() ?? "";

--- a/src/components/capsule/new/left/unlockOpt/Location.tsx
+++ b/src/components/capsule/new/left/unlockOpt/Location.tsx
@@ -93,7 +93,7 @@ export default function Location({
 
       {/* 조회 반경 */}
       <div className="flex flex-col space-y-2">
-        <span className="text-sm">조회 반경 (m)</span>
+        <label>조회 반경 (m)</label>
         <div className="flex flex-wrap gap-2">
           {VIEWING_RADIUS_OPTIONS.map((r) => {
             const selected = value.viewingRadius === r;

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -78,7 +78,11 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.lng ?? 0
         : 0,
-    viewingRadius: 0,
+    viewingRadius:
+      effectiveUnlockType === "LOCATION" ||
+      effectiveUnlockType === "TIME_AND_LOCATION"
+        ? locationForm.viewingRadius
+        : 0,
     packingColor: args.packingColor ?? "",
     contentColor: args.contentColor ?? "",
     maxViewCount: 0,
@@ -145,7 +149,11 @@ export function buildPrivatePayload(
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.lng ?? 0
         : 0,
-    viewingRadius: 0,
+    viewingRadius:
+      effectiveUnlockType === "LOCATION" ||
+      effectiveUnlockType === "TIME_AND_LOCATION"
+        ? locationForm.viewingRadius
+        : 0,
     packingColor,
     contentColor,
     maxViewCount: 0,
@@ -218,7 +226,7 @@ export function buildPublicPayload(
     locationRadiusM:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
-        ? 0
+        ? locationForm.viewingRadius
         : 0,
     maxViewCount: 0,
   };

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -61,7 +61,7 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
-        ? locationForm.placeName
+        ? locationForm.locationLabel?.trim() || locationForm.placeName
         : "",
     address:
       effectiveUnlockType === "LOCATION" ||
@@ -128,7 +128,7 @@ export function buildPrivatePayload(
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
-        ? locationForm.placeName
+        ? locationForm.locationLabel?.trim() || locationForm.placeName
         : "",
     address:
       effectiveUnlockType === "LOCATION" ||
@@ -203,7 +203,7 @@ export function buildPublicPayload(
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
-        ? locationForm.placeName
+        ? locationForm.locationLabel?.trim() || locationForm.placeName
         : "",
     locationLat:
       effectiveUnlockType === "LOCATION" ||

--- a/src/lib/kakao/types.ts
+++ b/src/lib/kakao/types.ts
@@ -1,0 +1,43 @@
+export type KakaoStatus = string;
+
+export type KakaoPlaceItem = {
+  id: string;
+  place_name: string;
+  x: string; // lng
+  y: string; // lat
+  address_name?: string;
+  road_address_name?: string;
+};
+
+export type KakaoCoord2AddressResult = Array<{
+  road_address?: { address_name?: string };
+  address?: { address_name?: string };
+}>;
+
+export type KakaoPlacesService = {
+  keywordSearch: (
+    query: string,
+    callback: (data: KakaoPlaceItem[], status: KakaoStatus) => void
+  ) => void;
+};
+
+export type KakaoGeocoderService = {
+  coord2Address: (
+    lng: number,
+    lat: number,
+    callback: (result: KakaoCoord2AddressResult, status: KakaoStatus) => void
+  ) => void;
+};
+
+export type KakaoNamespace = {
+  maps?: {
+    load?: (callback: () => void) => void;
+    services?: {
+      Places: new () => KakaoPlacesService;
+      Geocoder: new () => KakaoGeocoderService;
+      Status: { OK: KakaoStatus };
+    };
+  };
+};
+
+

--- a/src/lib/kakao/types.ts
+++ b/src/lib/kakao/types.ts
@@ -39,5 +39,3 @@ export type KakaoNamespace = {
     };
   };
 };
-
-

--- a/src/type/newCapsule.d.ts
+++ b/src/type/newCapsule.d.ts
@@ -9,6 +9,7 @@ type LocationForm = {
   query: string; // 사용자가 검색창에 입력한 값
   placeName: string; // 선택된 장소명(최종)
   locationLabel: string; // 사용자가 붙이는 장소 별칭(전송값)
+  viewingRadius: 50 | 100 | 300 | 500 | 1000; // 조회 반경(m)
   address?: string; // 선택된 주소(선택)
   lat?: number; // 좌표(선택)
   lng?: number; // 좌표(선택)

--- a/src/type/newCapsule.d.ts
+++ b/src/type/newCapsule.d.ts
@@ -8,6 +8,7 @@ type DayForm = {
 type LocationForm = {
   query: string; // 사용자가 검색창에 입력한 값
   placeName: string; // 선택된 장소명(최종)
+  locationLabel: string; // 사용자가 붙이는 장소 별칭(전송값)
   address?: string; // 선택된 주소(선택)
   lat?: number; // 좌표(선택)
   lng?: number; // 좌표(선택)


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
캡슐 생성 페이지의 “해제조건 > 장소” 기능을 구현했습니다.
 카카오맵을 통해 지도 클릭/장소 검색으로 좌표를 선택하고, 장소 별칭과 조회반경 을 입력해 캡슐 생성 payload에 반영합니다.
## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->
- Close #41 
- Close #42 
- Close #43  

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] Location.tsx를 폼 컨테이너로 유지하고 지도/검색 로직을 KakaoLocation.tsx로 분리
- [x] 카카오맵 연동
- [x] 지도 클릭으로 위/경도 선택
- [x] 키워드 장소 검색 및 결과 선택으로 위/경도 선택
- [x] “이 장소를 뭐라고 부를까요?” 입력(locationLabel) 추가 및 자동 채움(사용자 수정 시 덮어쓰기 방지)
- [x] 조회반경 선택 버튼(50/100/300/500/1000m) 추가 및 payload 반영
- [x] 지도 우측 하단 “내 위치로 이동” 버튼 추가(지도 중심 이동)
- [x] 내 위치로 이동 버튼을 누를 때, Geolocation 기반 위치 권한 차단/실패 시 안내 추가
- [x] capsule payload 빌더에서 위치/별칭/반경 값 매핑 정리
- [x] 내 위치 기준 반경 나타내는 원 구현

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="762" height="1060" alt="image" src="https://github.com/user-attachments/assets/eba91908-d3e1-4a6f-8006-5b4cdc0306f1" />
<img width="770" height="1151" alt="image" src="https://github.com/user-attachments/assets/06217c40-6781-48bc-a8a6-aaebeda6b668" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->


## 👥 리뷰 확인 사항


<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
위치 비허용시에도 지도가 나타나는건 의도한 사항입니다.(현재 위치 정보 얻는 것과 상관 없이, 캡슐 위치 설정은 할 수 있기 때문)
- 이 부분은 내 위치 이동 버튼 누르면 안내 메시지가 나타나도록 구현해놓았습니다.

--
지도 클릭으로 위·경도 얻기
지도 이벤트(클릭 이벤트): https://apis.map.kakao.com/web/documentation/#MapEvent
장소 검색(키워드 검색)
장소 검색(Places 서비스 / keywordSearch): https://apis.map.kakao.com/web/documentation/#services_Places
좌표 → 주소(역지오코딩)
좌표→주소 변환(Geocoder / coord2Address): https://apis.map.kakao.com/web/documentation/#services_Geocoder