### PR TITLE
[#66] feat(map): 캡슐 생성 시 열람 만료 시간 추가

### DIFF
--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -79,11 +79,17 @@ export default function WriteForm({
   const [sendMethod, setSendMethod] = useState("URL");
   const [unlockType, setUnlockType] = useState("TIME");
   const [dayForm, setDayForm] = useState<DayForm>({ date: "", time: "" });
+  const [isExpire, setIsExpire] = useState(false); //열람 만료 시간의 유무
+  //열람 만료 시간 데이터
+  const [expireDayForm, setExpireDayForm] = useState<DayForm>({
+    date: "",
+    time: "",
+  });
   const [locationForm, setLocationForm] = useState<LocationForm>({
     query: "",
     placeName: "",
     locationLabel: "",
-    viewingRadius: 100,
+    viewingRadius: 50,
     address: "",
     lat: undefined,
     lng: undefined,
@@ -274,6 +280,11 @@ export default function WriteForm({
       window.alert("해제 날짜와 시간을 모두 입력해 주세요.");
       return;
     }
+
+    if (isExpire && (!expireDayForm.date || !expireDayForm.time)) {
+      window.alert("만료 날짜와 시간을 모두 입력해 주세요.");
+      return;
+    }
     if (
       (effectiveUnlockType === "LOCATION" ||
         effectiveUnlockType === "TIME_AND_LOCATION") &&
@@ -301,6 +312,7 @@ export default function WriteForm({
       visibility: effectiveVisibility,
       effectiveUnlockType,
       dayForm,
+      expireDayForm,
       locationForm,
       packingColor: envelopeSelected?.name ?? "",
       contentColor: paperSelected?.name ?? "",
@@ -316,6 +328,7 @@ export default function WriteForm({
       visibility: effectiveVisibility,
       effectiveUnlockType,
       dayForm,
+      expireDayForm,
       locationForm,
       capsulePassword,
       capsuleColor: paperSelected?.name ?? "",
@@ -604,15 +617,28 @@ export default function WriteForm({
             />
             <div className="w-full p-4 border border-outline bg-[#F9F9FA] rounded-xl space-y-3">
               {unlockType === "TIME" && (
-                <DayTime value={dayForm} onChange={setDayForm} />
+                <DayTime
+                  visibility={visibility}
+                  isExpire={isExpire}
+                  onIsExpireChange={() => setIsExpire((state) => !state)}
+                  dayValue={dayForm}
+                  onDayChange={setDayForm}
+                  expireDayValue={expireDayForm}
+                  onExpireDayChange={setExpireDayForm}
+                />
               )}
               {unlockType === "LOCATION" && (
                 <Location value={locationForm} onChange={setLocationForm} />
               )}
               {unlockType === "MANUAL" && (
                 <DayLocation
+                  visibility={visibility}
+                  isExpire={isExpire}
+                  onIsExpireChange={() => setIsExpire((state) => !state)}
                   dayValue={dayForm}
                   onDayChange={setDayForm}
+                  expireDayValue={expireDayForm}
+                  onExpireDayChange={setExpireDayForm}
                   locationValue={locationForm}
                   onLocationChange={setLocationForm}
                 />

--- a/src/components/capsule/new/left/unlockOpt/DayLocation.tsx
+++ b/src/components/capsule/new/left/unlockOpt/DayLocation.tsx
@@ -2,19 +2,37 @@ import DayTime from "./DayTime";
 import Location from "./Location";
 
 export default function DayLocation({
+  visibility,
+  isExpire,
+  onIsExpireChange,
   dayValue,
   onDayChange,
   locationValue,
   onLocationChange,
+  expireDayValue,
+  onExpireDayChange,
 }: {
+  visibility: Visibility;
+  isExpire: boolean;
+  onIsExpireChange: () => void;
   dayValue: DayForm;
   onDayChange: (v: DayForm) => void;
+  expireDayValue: DayForm;
+  onExpireDayChange: (v: DayForm) => void;
   locationValue: LocationForm;
   onLocationChange: (v: LocationForm) => void;
 }) {
   return (
     <div className="space-y-4">
-      <DayTime value={dayValue} onChange={onDayChange} />
+      <DayTime
+        visibility={visibility}
+        isExpire={isExpire}
+        onIsExpireChange={onIsExpireChange}
+        dayValue={dayValue}
+        onDayChange={onDayChange}
+        expireDayValue={expireDayValue}
+        onExpireDayChange={onExpireDayChange}
+      />
       <div className="w-full h-px bg-outline"></div>
       <Location value={locationValue} onChange={onLocationChange} />
     </div>

--- a/src/components/capsule/new/left/unlockOpt/DayTime.tsx
+++ b/src/components/capsule/new/left/unlockOpt/DayTime.tsx
@@ -1,41 +1,115 @@
-import { Clock } from "lucide-react";
+import { Clock, Minus, PlusIcon } from "lucide-react";
 
 export default function DayTime({
-  value,
-  onChange,
+  visibility,
+  isExpire,
+  onIsExpireChange,
+  dayValue,
+  onDayChange,
+  expireDayValue,
+  onExpireDayChange,
 }: {
-  value: DayForm;
-  onChange: (v: DayForm) => void;
+  visibility: Visibility;
+  isExpire: boolean;
+  onIsExpireChange: () => void;
+  dayValue: DayForm;
+  onDayChange: (v: DayForm) => void;
+  expireDayValue: DayForm;
+  onExpireDayChange: (v: DayForm) => void;
 }) {
   return (
     <>
-      <div className="flex items-center gap-1">
-        <Clock size={16} />
-        <span className="text-sm">시간 설정</span>
-      </div>
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-1">
+            <Clock size={16} />
+            <span className="text-sm">열람 가능 시간</span>
+          </div>
 
-      <div className="flex flex-col space-y-2">
-        <label htmlFor="unlock-date">날짜</label>
-        <input
-          type="date"
-          name="unlockDate"
-          id="unlock-date"
-          value={value.date}
-          onChange={(e) => onChange({ ...value, date: e.target.value })}
-          className="bg-sub-2 rounded-lg text-sm p-2 outline-none border border-white/0 focus:border-primary-2"
-        />
-      </div>
+          <div className="flex flex-col space-y-2">
+            <label htmlFor="unlock-date">날짜</label>
+            <input
+              type="date"
+              name="unlockDate"
+              id="unlock-date"
+              value={dayValue.date}
+              onChange={(e) =>
+                onDayChange({ ...dayValue, date: e.target.value })
+              }
+              className="bg-sub-2 rounded-lg text-sm p-2 outline-none border border-white/0 focus:border-primary-2"
+            />
+          </div>
 
-      <div className="flex flex-col space-y-2">
-        <label htmlFor="unlock-time">시간</label>
-        <input
-          type="time"
-          name="unlockTime"
-          id="unlock-time"
-          value={value.time}
-          onChange={(e) => onChange({ ...value, time: e.target.value })}
-          className="bg-sub-2 rounded-lg text-sm p-2 outline-none border border-white/0 focus:border-primary-2"
-        />
+          <div className="flex flex-col space-y-2">
+            <label htmlFor="unlock-time">시간</label>
+            <input
+              type="time"
+              name="unlockTime"
+              id="unlock-time"
+              value={dayValue.time}
+              onChange={(e) =>
+                onDayChange({ ...dayValue, time: e.target.value })
+              }
+              className="bg-sub-2 rounded-lg text-sm p-2 outline-none border border-white/0 focus:border-primary-2"
+            />
+          </div>
+        </div>
+
+        {visibility === "SELF" ? (
+          ""
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div
+              className="flex items-center justify-between "
+              onClick={onIsExpireChange}
+            >
+              <div className="flex items-center gap-1">
+                <Clock size={16} />
+                <span className="text-sm">열람 만료 시간</span>
+              </div>
+              {isExpire ? <Minus size={16} /> : <PlusIcon size={16}></PlusIcon>}
+            </div>
+            {isExpire ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col space-y-2">
+                  <label htmlFor="unlock-date">날짜</label>
+                  <input
+                    type="date"
+                    name="unlockDate"
+                    id="unlock-date"
+                    value={expireDayValue.date}
+                    onChange={(e) =>
+                      onExpireDayChange({
+                        ...expireDayValue,
+                        date: e.target.value,
+                      })
+                    }
+                    className="bg-sub-2 rounded-lg text-sm p-2 outline-none border border-white/0 focus:border-primary-2"
+                  />
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                  <label htmlFor="unlock-time">시간</label>
+                  <input
+                    type="time"
+                    name="unlockTime"
+                    id="unlock-time"
+                    value={expireDayValue.time}
+                    onChange={(e) =>
+                      onExpireDayChange({
+                        ...expireDayValue,
+                        time: e.target.value,
+                      })
+                    }
+                    className="bg-sub-2 rounded-lg text-sm p-2 outline-none border border-white/0 focus:border-primary-2"
+                  />
+                </div>
+              </div>
+            ) : (
+              ""
+            )}
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/components/capsule/new/left/unlockOpt/Location.tsx
+++ b/src/components/capsule/new/left/unlockOpt/Location.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useRef } from "react";
 import KakaoLocation, { type KakaoLocationHandle } from "./KakaoLocation";
 
 // 조회 반경
-const VIEWING_RADIUS_OPTIONS = [50, 100, 300, 500, 1000] as const;
+// const VIEWING_RADIUS_OPTIONS = [50, 100, 300, 500, 1000] as const;
 
 export default function Location({
   value,
@@ -27,7 +27,7 @@ export default function Location({
     <>
       <div className="flex items-center gap-1">
         <MapPin size={16} />
-        <span className="text-sm">장소 설정</span>
+        <span className="text-sm">열람 가능 장소</span>
       </div>
 
       {/* 검색 입력 */}
@@ -92,7 +92,7 @@ export default function Location({
       />
 
       {/* 조회 반경 */}
-      <div className="flex flex-col space-y-2">
+      {/* <div className="flex flex-col space-y-2">
         <label>조회 반경 (m)</label>
         <div className="flex flex-wrap gap-2">
           {VIEWING_RADIUS_OPTIONS.map((r) => {
@@ -114,7 +114,7 @@ export default function Location({
             );
           })}
         </div>
-      </div>
+      </div> */}
 
       {/* 사용자 지정 이름 */}
       <div className="flex flex-col space-y-2">

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -17,6 +17,7 @@ type BuildCommonArgs = {
   visibility: Visibility;
   effectiveUnlockType: UnlockType;
   dayForm: DayForm;
+  expireDayForm?: DayForm;
   locationForm: LocationForm;
   capsulePassword?: string | null;
   capsuleColor?: string;
@@ -107,6 +108,7 @@ export function buildPrivatePayload(
     visibility,
     effectiveUnlockType,
     dayForm,
+    expireDayForm,
     locationForm,
     packingColor = "",
     contentColor = "",
@@ -115,6 +117,13 @@ export function buildPrivatePayload(
     effectiveUnlockType === "TIME" ||
     effectiveUnlockType === "TIME_AND_LOCATION"
       ? new Date(`${dayForm.date}T${dayForm.time}:00`).toISOString()
+      : undefined;
+
+  const unlockUntil =
+    expireDayForm &&
+    (effectiveUnlockType === "TIME" ||
+      effectiveUnlockType === "TIME_AND_LOCATION")
+      ? new Date(`${expireDayForm.date}T${expireDayForm.time}:00`).toISOString()
       : undefined;
 
   return {
@@ -128,7 +137,7 @@ export function buildPrivatePayload(
     visibility,
     unlockType: effectiveUnlockType,
     unlockAt,
-    unlockUntil: undefined,
+    unlockUntil,
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
@@ -176,6 +185,7 @@ export function buildPublicPayload(
     visibility,
     effectiveUnlockType,
     dayForm,
+    expireDayForm,
     locationForm,
     capsuleColor = "",
     capsulePackingColor = "",
@@ -187,6 +197,13 @@ export function buildPublicPayload(
     effectiveUnlockType === "TIME" ||
     effectiveUnlockType === "TIME_AND_LOCATION"
       ? new Date(`${dayForm.date}T${dayForm.time}:00`).toISOString()
+      : undefined;
+
+  const unlockUntil =
+    expireDayForm &&
+    (effectiveUnlockType === "TIME" ||
+      effectiveUnlockType === "TIME_AND_LOCATION")
+      ? new Date(`${expireDayForm.date}T${expireDayForm.time}:00`).toISOString()
       : undefined;
 
   return {
@@ -202,7 +219,7 @@ export function buildPublicPayload(
     visibility,
     unlockType: effectiveUnlockType,
     unlockAt,
-    unlockUntil: undefined,
+    unlockUntil,
     address:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"

--- a/src/type/newCapsule.d.ts
+++ b/src/type/newCapsule.d.ts
@@ -9,7 +9,7 @@ type LocationForm = {
   query: string; // 사용자가 검색창에 입력한 값
   placeName: string; // 선택된 장소명(최종)
   locationLabel: string; // 사용자가 붙이는 장소 별칭(전송값)
-  viewingRadius: 50 | 100 | 300 | 500 | 1000; // 조회 반경(m)
+  viewingRadius: 50; // 조회 반경(m)
   address?: string; // 선택된 주소(선택)
   lat?: number; // 좌표(선택)
   lng?: number; // 좌표(선택)


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
캡슐 생성 시 열람 만료 시간 추가

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #66

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 캡슐 생성 시 열람 만료 시간 추가
- [x] 열람 반경 50으로 고정
 
## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- 시간, 시간+공간 기반일때만 열람 만료 시간이 나오도록 구현했습니다.
그런데 구현 후 노션 문서(https://www.notion.so/BE-2-2ca9d0051b998070901fef7f588050ba?v=2bd9d0051b99817da42d000c12c81e12&source=copy_link)를 확인해보니 시간 기반일때만 적용한다고 하셔서 이부분 다시 확인이 필요할 것 같습니다.
- 시간, 시간+공간 기반일때만 unLockUntil에 값을 넣어 생성 API를 호출합니다. 

