### PR TITLE
fix(CapsuleRead): 조회 관련 버그 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["pageable"]
+}

--- a/src/app/(user)/dashboard/DashboardShell.tsx
+++ b/src/app/(user)/dashboard/DashboardShell.tsx
@@ -17,16 +17,13 @@ export default function DashboardShell({
   // 한번 닫으면 이 세션에서는 안 뜨게(원하면 localStorage로 확장 가능)
   const [dismissed, setDismissed] = useState(false);
 
-  // ✅ state로 setOpen 하지 말고 "계산된 open" 사용
+  // state로 setOpen 하지 말고 "계산된 open" 사용
   const open = needs && !dismissed;
 
   return (
     <>
       {children}
-      <OAuthProfileModal
-        open={open}
-        onClose={() => setDismissed(true)}
-      />
+      <OAuthProfileModal open={open} onClose={() => setDismissed(true)} />
     </>
   );
 }

--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -462,7 +462,14 @@ export default function LetterDetailModal({
   const isReadByOther = isSender && !!capsule.viewStatus;
   const canEdit = isSender && !isReadByOther;
 
-  const detailHex = CAPTURE_COLOR_MAP[capsule.capsuleColor ?? "BEIGE"];
+  const DEFAULT_HEX = CAPTURE_COLOR_MAP.BEIGE ?? "#FFDED8";
+
+  const detailKey = (capsule.capsuleColor ?? "BEIGE")
+    .toString()
+    .trim()
+    .toUpperCase() as keyof typeof CAPTURE_COLOR_MAP;
+
+  const detailHex = CAPTURE_COLOR_MAP[detailKey] ?? DEFAULT_HEX;
 
   return (
     <div className="fixed inset-0 z-9999 bg-black/50 w-full min-h-screen">

--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -422,7 +422,7 @@ export default function LetterDetailModal({
           capsuleColor: s.capsuleColor ?? null,
           title: s.title,
           content: s.content,
-          createdAt: s.createAt,
+          createdAt: s.createdAt,
           writerNickname: s.senderNickname,
           recipient: s.recipient ?? null,
 
@@ -459,7 +459,7 @@ export default function LetterDetailModal({
         capsuleColor: u.capsuleColor ?? null,
         title: u.title,
         content: u.content,
-        createdAt: u.createAt,
+        createdAt: u.createdAt,
         writerNickname: u.senderNickname,
         recipient: u.recipient ?? null,
 

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -35,10 +35,6 @@ import {
   buildMyPayload,
   createMyCapsule,
 } from "@/lib/api/capsule/capsule";
-import type {
-  UnlockType,
-  CapsuleCreateResponse,
-} from "@/lib/api/capsule/types";
 
 type PreviewState = {
   title: string;

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -277,10 +277,15 @@ export default function WriteForm({
       return;
     }
 
-    if (isExpire && (!expireDayForm.date || !expireDayForm.time)) {
-      window.alert("만료 날짜와 시간을 모두 입력해 주세요.");
+    if (
+      isExpire &&
+      ((expireDayForm.date && !expireDayForm.time) ||
+        (!expireDayForm.date && expireDayForm.time))
+    ) {
+      window.alert("만료 날짜/시간은 둘 다 입력하거나, 둘 다 비워두세요.");
       return;
     }
+
     if (
       (effectiveUnlockType === "LOCATION" ||
         effectiveUnlockType === "TIME_AND_LOCATION") &&

--- a/src/components/capsule/new/left/unlockOpt/DayTime.tsx
+++ b/src/components/capsule/new/left/unlockOpt/DayTime.tsx
@@ -17,6 +17,13 @@ export default function DayTime({
   expireDayValue: DayForm;
   onExpireDayChange: (v: DayForm) => void;
 }) {
+  const handleExpireToggle = () => {
+    if (!isExpire) {
+      onExpireDayChange({ date: "", time: "" });
+    }
+    onIsExpireChange();
+  };
+
   return (
     <>
       <div className="flex flex-col gap-5">
@@ -60,23 +67,24 @@ export default function DayTime({
         ) : (
           <div className="flex flex-col gap-2">
             <div
-              className="flex items-center justify-between "
-              onClick={onIsExpireChange}
+              className="flex items-center justify-between"
+              onClick={handleExpireToggle}
             >
               <div className="flex items-center gap-1">
                 <Clock size={16} />
                 <span className="text-sm">열람 만료 시간</span>
               </div>
-              {isExpire ? <Minus size={16} /> : <PlusIcon size={16}></PlusIcon>}
+              {isExpire ? <Minus size={16} /> : <PlusIcon size={16} />}
             </div>
+
             {isExpire ? (
               <div className="flex flex-col gap-2">
                 <div className="flex flex-col space-y-2">
-                  <label htmlFor="unlock-date">날짜</label>
+                  <label htmlFor="expire-date">날짜</label>
                   <input
                     type="date"
-                    name="unlockDate"
-                    id="unlock-date"
+                    name="expireDate"
+                    id="expire-date"
                     value={expireDayValue.date}
                     onChange={(e) =>
                       onExpireDayChange({
@@ -89,11 +97,11 @@ export default function DayTime({
                 </div>
 
                 <div className="flex flex-col space-y-2">
-                  <label htmlFor="unlock-time">시간</label>
+                  <label htmlFor="expire-time">시간</label>
                   <input
                     type="time"
-                    name="unlockTime"
-                    id="unlock-time"
+                    name="expireTime"
+                    id="expire-time"
                     value={expireDayValue.time}
                     onChange={(e) =>
                       onExpireDayChange({

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -27,7 +27,7 @@ export default function Modal({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 12, scale: 0.98 }}
             transition={{ duration: 0.18, ease: "easeOut" }}
-            onMouseDown={(e) => e.stopPropagation()} // ✅ 모달 내부 클릭은 닫히지 않게
+            onMouseDown={(e) => e.stopPropagation()}
           >
             {children}
           </motion.div>

--- a/src/components/dashboard/contents/mailbox/EnvelopeCard.tsx
+++ b/src/components/dashboard/contents/mailbox/EnvelopeCard.tsx
@@ -1,75 +1,232 @@
 /* eslint-disable react-hooks/static-components */
 "use client";
 
+import { useMemo } from "react";
 import { formatDateTime } from "@/lib/hooks/formatDateTime";
 import Logo from "@/components/common/Logo";
-import { Clock, Lock, MapPin, Unlock } from "lucide-react";
+import { Clock, Lock, MapPin, Unlock, Pencil, PencilOff } from "lucide-react";
 import Link from "next/link";
+import { CAPTURE_COLOR_MAP } from "@/constants/capsulePalette";
+
+type LatLng = { lat: number; lng: number };
 
 type Props = {
   capsule: CapsuleDashboardItem;
   type: "send" | "receive" | "bookmark";
+  currentPos?: LatLng | null;
 };
 
-function getUnlockInfo(capsule: CapsuleDashboardItem) {
-  const unlockType = (capsule.unlockType ?? "").toUpperCase();
-  const isTime = unlockType === "TIME" || unlockType === "TIME_AND_LOCATION";
+/* 위치 계산 */
+function distanceMeters(a: LatLng, b: LatLng) {
+  const R = 6371e3;
+  const toRad = (v: number) => (v * Math.PI) / 180;
 
-  const conditionLabel = isTime
-    ? capsule.unlockAt
-      ? formatDateTime(capsule.unlockAt)
-      : "시간 조건 없음"
-    : capsule.locationName ?? "위치 조건 없음";
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+
+  const x =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+  return R * c;
+}
+
+/* 타입 별 UI */
+function getEnvelopeStatus(
+  capsule: CapsuleDashboardItem,
+  type: Props["type"],
+  currentPos?: LatLng | null
+) {
+  const isRead = !!capsule.viewStatus;
+
+  // send: 잠금 조건 대신 열람/수정 상태만
+  if (type === "send") {
+    const canEdit = !isRead;
+    const statusText = isRead ? "상대가 읽음" : "아직 안 읽음";
+    const editText = canEdit ? "수정 가능" : "수정 불가";
+
+    return {
+      mode: "send" as const,
+      isRead,
+      canEdit,
+      statusText,
+      editText,
+    };
+  }
+
+  const unlockType = (capsule.unlockType ?? "").toUpperCase();
+  const needsTime = unlockType === "TIME" || unlockType === "TIME_AND_LOCATION";
+  const needsLocation =
+    unlockType === "LOCATION" || unlockType === "TIME_AND_LOCATION";
+
+  // --- 시간 조건 ---
+  const timeLabel = capsule.unlockAt
+    ? formatDateTime(capsule.unlockAt)
+    : "시간 조건 없음";
 
   const isUnlockedByTime =
-    isTime && capsule.unlockAt
+    needsTime && capsule.unlockAt
       ? Date.now() >= new Date(capsule.unlockAt).getTime()
-      : true;
+      : !needsTime;
+
+  // --- 위치 조건 ---
+  const targetLat = capsule.locationLat;
+  const targetLng = capsule.locationLng;
+
+  const radiusM = 50;
+
+  const hasTarget =
+    typeof targetLat === "number" && typeof targetLng === "number";
+  const canCheckLocation = !!currentPos && hasTarget;
+
+  const isUnlockedByLocation = needsLocation
+    ? canCheckLocation
+      ? distanceMeters(currentPos!, { lat: targetLat!, lng: targetLng! }) <=
+        radiusM
+      : false
+    : true;
+
+  // 표시 라벨
+  const conditionLabel =
+    needsTime && needsLocation
+      ? `${timeLabel} · ${capsule.locationName ?? "위치 조건 없음"}`
+      : needsTime
+      ? timeLabel
+      : capsule.locationName ?? "위치 조건 없음";
 
   const isUnlocked =
     unlockType === "TIME"
       ? isUnlockedByTime
       : unlockType === "LOCATION"
-      ? false
+      ? isUnlockedByLocation
       : unlockType === "TIME_AND_LOCATION"
-      ? false
+      ? isUnlockedByTime && isUnlockedByLocation
       : true;
-  const isRead = capsule.viewStatus;
+
   const statusText = isUnlocked ? "열람 가능" : "열람 불가능";
 
-  return { isTime, conditionLabel, isUnlocked, isRead, statusText };
+  // 위치 조건인데 아직 currentPos가 없거나 target 좌표가 없으면 안내
+  const locationHint =
+    needsLocation && !canCheckLocation ? "현재 위치로 확인 중..." : null;
+
+  return {
+    mode: "unlock" as const,
+    isTime: needsTime,
+    conditionLabel,
+    isUnlocked,
+    isRead,
+    statusText,
+    locationHint,
+  };
 }
 
-export default function EnvelopeCard({ capsule, type }: Props) {
-  const { isTime, conditionLabel, isUnlocked, isRead, statusText } =
-    getUnlockInfo(capsule);
+/* 뒷면 색상 */
+function clamp(n: number, min = 0, max = 255) {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeHex(hex: unknown, fallback = "#FFDED8") {
+  if (typeof hex !== "string" || hex.trim() === "") return fallback;
+
+  const h = hex.trim().startsWith("#") ? hex.trim() : `#${hex.trim()}`;
+
+  if (!/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(h)) return fallback;
+  return h;
+}
+
+function hexToRgb(hex: unknown) {
+  const safe = normalizeHex(hex);
+  const h = safe.replace("#", "");
+
+  const full =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  const num = parseInt(full, 16);
+
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255,
+  };
+}
+
+function rgbToHex(r: number, g: number, b: number) {
+  const toHex = (v: number) => clamp(v).toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function shiftColor(hex: unknown, amount: number, fallback = "#FFDED8") {
+  const safe = normalizeHex(hex, fallback);
+  const { r, g, b } = hexToRgb(safe);
+  return rgbToHex(r + amount, g + amount, b + amount);
+}
+
+export default function EnvelopeCard({
+  capsule,
+  type,
+  currentPos = null,
+}: Props) {
+  const status = useMemo(
+    () => getEnvelopeStatus(capsule, type, currentPos),
+    [capsule, type, currentPos]
+  );
 
   const href = `/dashboard/${type}?id=${capsule.capsuleId}`;
 
-  /** "이미 읽음"일 때 넣을 UI 자리 */
-  const ReadBadgeSlot = () =>
-    isUnlocked && isRead ? (
+  // send는 항상 상세 진입 가능
+  const canOpenDetail =
+    type === "send" || (status.mode === "unlock" && status.isUnlocked);
+
+  const ReadBadgeSlot = () => {
+    if (type === "send") return null;
+
+    return status.mode === "unlock" && status.isUnlocked && status.isRead ? (
       <div className="absolute top-3 left-3 z-10">
         <div className="px-2 py-1 rounded-full text-xs bg-white/80 shadow">
           읽음
         </div>
       </div>
     ) : null;
+  };
+
+  const DEFAULT_HEX = CAPTURE_COLOR_MAP.BEIGE ?? "#FFDED8";
+
+  const packingKey = (capsule.capsulePackingColor ?? "BEIGE")
+    .toString()
+    .trim()
+    .toUpperCase() as keyof typeof CAPTURE_COLOR_MAP;
+
+  const packingHex = CAPTURE_COLOR_MAP[packingKey] ?? DEFAULT_HEX;
+
+  const backBase = packingHex;
+  const backShade1 = shiftColor(backBase, 0); // 바닥
+  const backShade2 = shiftColor(backBase, -5); // 아래 삼각
+  const backShade3 = shiftColor(backBase, +5); // 위 삼각 (조금 밝게)
 
   const CardInner = () => (
     <div className="relative flex flex-col items-center justify-center p-2 perspective-[1000px] group">
-      {/* 읽음 UI 슬롯 */}
       <ReadBadgeSlot />
 
-      {/* Flip wrapper */}
-      <div className="relative w-[280px] h-[180px] transition-transform duration-500 transform-3d group-hover:transform-[rotateY(180deg)]">
-        {/* ------------------------- 앞면 ------------------------- */}
+      <div className="relative w-70 h-45 transition-transform duration-500 transform-3d group-hover:transform-[rotateY(180deg)]">
+        {/* 앞면 */}
         <div className="absolute inset-0 backface-hidden">
-          <div className="relative w-full h-full bg-linear-to-b from-[#FFEAEA] to-[#FDCACA] p-3">
+          <div
+            className="relative w-full h-full p-3"
+            style={{ backgroundColor: backBase }}
+          >
             <div className="flex justify-between h-full text-sm">
-              {/* 수신자 */}
               <div className="w-2/5">
-                <p className="line-clamp-1">Dear.{capsule.recipient}</p>
+                <p className="line-clamp-1">
+                  Dear.{capsule.recipient ?? "(수신자 정보 없음)"}
+                </p>
                 <div className="space-y-2">
                   <div className="w-full h-px bg-white"></div>
                   <div className="flex gap-0.5">
@@ -80,7 +237,6 @@ export default function EnvelopeCard({ capsule, type }: Props) {
                 </div>
               </div>
 
-              {/* 발신자 */}
               <div className="w-2/5 h-full flex flex-col">
                 <div className="flex flex-col items-end mt-auto">
                   <p className="line-clamp-1">From. {capsule.sender}</p>
@@ -96,73 +252,104 @@ export default function EnvelopeCard({ capsule, type }: Props) {
               </div>
             </div>
 
-            {/* 가운데 제목 */}
             <div className="absolute top-1/2 left-1/2 -translate-1/2 w-30">
               <p className="text-center text-sm line-clamp-3">
                 {capsule.title}
               </p>
             </div>
 
-            {/* 조건 아이콘 */}
             <div className="absolute top-0 right-0">
               <div className="text-primary p-4 space-y-2">
-                {isTime ? <Clock size={16} /> : <MapPin size={16} />}
+                {type === "send" ? (
+                  status.mode === "send" && status.canEdit ? (
+                    <Pencil size={16} />
+                  ) : (
+                    <PencilOff size={16} />
+                  )
+                ) : status.mode === "unlock" && status.isTime ? (
+                  <Clock size={16} />
+                ) : (
+                  <MapPin size={16} />
+                )}
               </div>
             </div>
 
-            {/* 로고 */}
             <div className="absolute bottom-3 left-3 text-white">
               <Logo className="w-5" />
             </div>
           </div>
         </div>
 
-        {/* ------------------------- 뒷면 ------------------------- */}
+        {/* 뒷면 */}
         <div className="absolute inset-0 backface-hidden transform-[rotateY(180deg)]">
           <div className="w-full h-full flex items-center justify-center">
             <div className="absolute inset-0">
-              <svg
-                width="280"
-                height="180"
-                viewBox="0 0 280 180"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M0 0H280V180H0V0Z" fill="#FFDFDF" />
-                <path d="M280 180H0L140 86L280 180Z" fill="#FFD3D3" />
-                <path d="M280 0H0L140 118L280 0Z" fill="#FFEAEA" />
+              <svg width="280" height="180" viewBox="0 0 280 180" fill="none">
+                <path d="M0 0H280V180H0V0Z" fill={backShade1} />
+                <path d="M280 180H0L140 86L280 180Z" fill={backShade2} />
+                <path d="M280 0H0L140 118L280 0Z" fill={backShade3} />
               </svg>
             </div>
 
             <div className="relative text-text-2 flex flex-col items-center justify-center gap-2">
-              <span className="font-medium">{statusText}</span>
-              <div className="w-15 h-15 rounded-full bg-white shadow-lg flex items-center justify-center">
-                {isUnlocked ? <Unlock /> : <Lock />}
-              </div>
+              {type === "send" && status.mode === "send" ? (
+                <>
+                  <span className="font-medium">{status.statusText}</span>
+                  <div className="w-15 h-15 rounded-full bg-white shadow-lg flex items-center justify-center">
+                    {status.isRead ? <Lock /> : <Unlock />}
+                  </div>
+                  <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-white shadow-lg">
+                    {status.canEdit ? (
+                      <Pencil size={14} />
+                    ) : (
+                      <PencilOff size={14} />
+                    )}
+                    <span className="text-xs">{status.editText}</span>
+                  </div>
+                  {status.canEdit ? (
+                    <span className="text-xs">클릭하여 확인/수정</span>
+                  ) : (
+                    <span className="text-xs text-text-3">
+                      열람 후에는 수정할 수 없어요
+                    </span>
+                  )}
+                </>
+              ) : status.mode === "unlock" ? (
+                <>
+                  <span className="font-medium">{status.statusText}</span>
+                  <div className="w-15 h-15 rounded-full bg-white shadow-lg flex items-center justify-center">
+                    {status.isUnlocked ? <Unlock /> : <Lock />}
+                  </div>
 
-              {/* 열람 가능 + 미열람일 때 */}
-              {isUnlocked && !isRead ? (
-                <span className="text-xs">클릭하여 읽기</span>
-              ) : null}
+                  {status.isUnlocked && !status.isRead ? (
+                    <span className="text-xs">클릭하여 읽기</span>
+                  ) : null}
 
-              {/* 잠금일 때 조건 표시 */}
-              {!isUnlocked ? (
-                <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-white shadow-lg">
-                  {isTime ? <Clock size={14} /> : <MapPin size={14} />}
-                  <span className="text-xs line-clamp-1">{conditionLabel}</span>
-                </div>
-              ) : null}
+                  {!status.isUnlocked ? (
+                    <>
+                      <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-white shadow-lg">
+                        {status.isTime ? (
+                          <Clock size={14} />
+                        ) : (
+                          <MapPin size={14} />
+                        )}
+                        <span className="text-xs line-clamp-1">
+                          {status.conditionLabel}
+                        </span>
+                      </div>
 
-              {/* 해제 안 됐을 때 클릭 불가 안내(원하면) */}
-              {!isUnlocked ? (
-                <span className="text-xs text-text-3">해제 후 열람 가능</span>
+                      <span className="text-xs text-text-3">
+                        {status.locationHint ?? "해제 후 열람 가능"}
+                      </span>
+                    </>
+                  ) : null}
+                </>
               ) : null}
             </div>
           </div>
         </div>
       </div>
 
-      {/* Shadow */}
       <div
         className="absolute w-60 h-px rounded-[30%]"
         style={{ boxShadow: "20px 100px 10px 5px #EEEEF3" }}
@@ -170,20 +357,14 @@ export default function EnvelopeCard({ capsule, type }: Props) {
     </div>
   );
 
-  // 잠김이면 Link 대신 div로 렌더 → 클릭 불가
-  if (!isUnlocked) {
+  if (!canOpenDetail) {
     return (
-      <div
-        className="cursor-not-allowed opacity-80"
-        aria-disabled="true"
-        onClick={(e) => e.preventDefault()}
-      >
+      <div className="cursor-not-allowed opacity-80" aria-disabled="true">
         <CardInner />
       </div>
     );
   }
 
-  // 해제되면 Link로 이동 가능
   return (
     <Link href={href} scroll={false} className="block">
       <CardInner />

--- a/src/components/dashboard/contents/mailbox/MailboxPage.tsx
+++ b/src/components/dashboard/contents/mailbox/MailboxPage.tsx
@@ -71,7 +71,7 @@ export default function MailboxPage({
 
   const size = isBookmark ? 24 : 10;
 
-  // 1) send/receive infinite
+  // 1) send/receive
   const sendReceiveInf = useInfiniteQuery({
     enabled: !isBookmark,
     queryKey: ["capsuleDashboard", type, "infinite", size],
@@ -86,7 +86,6 @@ export default function MailboxPage({
       return capsuleDashboardApi.receiveDashboard({ page, size }, signal);
     },
     getNextPageParam: (lastPage) => {
-      // PageResponse<CapsuleDashboardItem>
       const d = lastPage.data;
       if (d.last) return undefined;
       // number는 현재 페이지 index
@@ -94,7 +93,7 @@ export default function MailboxPage({
     },
   });
 
-  // 2) bookmark infinite
+  // 2) bookmark
   const bookmarkInf = useInfiniteQuery({
     enabled: isBookmark,
     queryKey: ["bookmarks", "infinite", size],

--- a/src/components/dashboard/contents/mailbox/MailboxPage.tsx
+++ b/src/components/dashboard/contents/mailbox/MailboxPage.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react-hooks/set-state-in-effect */
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import DivBox from "../../DivBox";
 import EnvelopeCard from "./EnvelopeCard";
 import { Bookmark, Inbox, Send } from "lucide-react";
@@ -23,21 +23,36 @@ function useCurrentPositionOnce(enabled: boolean) {
     }
 
     navigator.geolocation.getCurrentPosition(
-      (p) => {
-        setPos({ lat: p.coords.latitude, lng: p.coords.longitude });
-      },
-      () => {
-        setPos(null);
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 10_000,
-        maximumAge: 30_000, // 30초 캐시 허용
-      }
+      (p) => setPos({ lat: p.coords.latitude, lng: p.coords.longitude }),
+      () => setPos(null),
+      { enableHighAccuracy: true, timeout: 10_000, maximumAge: 30_000 }
     );
   }, [enabled]);
 
   return pos;
+}
+
+function useInfiniteScrollTrigger(
+  enabled: boolean,
+  onIntersect: () => void,
+  options?: IntersectionObserverInit
+) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const io = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) onIntersect();
+    }, options);
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, [enabled, onIntersect, options]);
+
+  return ref;
 }
 
 export default function MailboxPage({
@@ -52,52 +67,103 @@ export default function MailboxPage({
   }[type];
 
   const isBookmark = type === "bookmark";
-
-  // receive/bookmark에서만 위치가 필요하니까 그때만 1회 획득
   const currentPos = useCurrentPositionOnce(type !== "send");
 
-  const { data, isLoading, error } = useQuery<
-    CapsuleDashboardItem[] | BookmarkPageResponse
-  >({
-    queryKey: isBookmark
-      ? ["bookmarks", { page: 0, size: 24 }]
-      : ["capsuleDashboard", type],
-    queryFn: ({ signal }) => {
-      if (type === "send") return capsuleDashboardApi.sendDashboard(signal);
-      if (type === "receive")
-        return capsuleDashboardApi.receiveDashboard(signal);
+  const size = isBookmark ? 24 : 10;
 
-      return capsuleDashboardApi.bookmarks(
-        { page: 0, size: 24, sort: ["bookmarkedAt,desc"] },
-        signal
-      );
+  // 1) send/receive infinite
+  const sendReceiveInf = useInfiniteQuery({
+    enabled: !isBookmark,
+    queryKey: ["capsuleDashboard", type, "infinite", size],
+    initialPageParam: 0,
+    queryFn: ({ signal, pageParam }) => {
+      const page = pageParam as number;
+
+      if (type === "send") {
+        return capsuleDashboardApi.sendDashboard({ page, size }, signal);
+      }
+      // receive
+      return capsuleDashboardApi.receiveDashboard({ page, size }, signal);
+    },
+    getNextPageParam: (lastPage) => {
+      // PageResponse<CapsuleDashboardItem>
+      const d = lastPage.data;
+      if (d.last) return undefined;
+      // number는 현재 페이지 index
+      return d.number + 1;
     },
   });
 
+  // 2) bookmark infinite
+  const bookmarkInf = useInfiniteQuery({
+    enabled: isBookmark,
+    queryKey: ["bookmarks", "infinite", size],
+    initialPageParam: 0,
+    queryFn: ({ signal, pageParam }) => {
+      const page = pageParam as number;
+      return capsuleDashboardApi.bookmarks(
+        { page, size, sort: ["bookmarkedAt,desc"] },
+        signal
+      );
+    },
+    getNextPageParam: (lastPage: BookmarkPageResponse) => {
+      return lastPage.last ? undefined : lastPage.page + 1;
+    },
+  });
+
+  // 공통 선택
+  const active = isBookmark ? bookmarkInf : sendReceiveInf;
+
+  const isLoading = active.isLoading;
+  const error = active.error;
+
   const { list, totalCount } = useMemo(() => {
-    if (!data) return { list: [] as CapsuleDashboardItem[], totalCount: 0 };
+    if (!active.data)
+      return { list: [] as CapsuleDashboardItem[], totalCount: 0 };
 
     if (isBookmark) {
-      const page = data as BookmarkPageResponse;
+      const pages = active.data.pages as BookmarkPageResponse[];
 
-      const adapted: CapsuleDashboardItem[] = page.content.map((b) => ({
-        capsuleId: b.capsuleId,
-        sender: b.sender,
-        title: b.title,
-        content: b.contentPreview,
-        createAt: b.bookmarkedAt,
-        viewStatus: b.isViewed,
-      }));
+      const adapted = pages.flatMap((p) =>
+        p.content.map((b) => ({
+          capsuleId: b.capsuleId,
+          sender: b.sender,
+          title: b.title,
+          content: b.contentPreview,
+          createAt: b.bookmarkedAt,
+          viewStatus: b.isViewed,
+        }))
+      );
 
-      return { list: adapted, totalCount: page.totalElements };
+      const first = pages[0];
+      return {
+        list: adapted,
+        totalCount: first?.totalElements ?? adapted.length,
+      };
     }
 
-    const arr = data as CapsuleDashboardItem[];
-    return { list: arr, totalCount: arr.length };
-  }, [data, isBookmark]);
+    const pages = active.data.pages as PageResponse<CapsuleDashboardItem>[];
+    const merged = pages.flatMap((p) => p.data.content);
+
+    const first = pages[0];
+    return {
+      list: merged,
+      totalCount: first?.data.totalElements ?? merged.length,
+    };
+  }, [active.data, isBookmark]);
+
+  // 바닥 감지 → 다음 페이지 로드
+  const sentinelRef = useInfiniteScrollTrigger(
+    Boolean(active.hasNextPage) && !active.isFetchingNextPage,
+    () => active.fetchNextPage(),
+    { rootMargin: "200px" } // 바닥 200px 전에 미리 로딩
+  );
 
   if (isLoading) return <MailboxSkeleton />;
-  if (error) return <div>에러 발생</div>;
+  if (error) {
+    console.error("MailboxPage query error:", error);
+    return <div>에러 발생</div>;
+  }
 
   return (
     <section className="flex-1 w-full">
@@ -125,15 +191,33 @@ export default function MailboxPage({
                 {isBookmark ? "북마크한 편지가 없습니다" : "편지가 없습니다"}
               </p>
             ) : (
-              list.map((capsule) => (
-                <EnvelopeCard
-                  key={capsule.capsuleId}
-                  capsule={capsule}
-                  type={type}
-                  // 위치 1회 획득값을 카드에 전달
-                  currentPos={currentPos}
-                />
-              ))
+              <>
+                {list.map((capsule) => (
+                  <EnvelopeCard
+                    key={capsule.capsuleId}
+                    capsule={capsule}
+                    type={type}
+                    currentPos={currentPos}
+                  />
+                ))}
+
+                {/* 무한스크롤 트리거 */}
+                <div ref={sentinelRef} className="w-full h-8" />
+
+                {/* 다음 페이지 로딩 표시 */}
+                {active.isFetchingNextPage && (
+                  <div className="w-full text-center text-sm text-text-3">
+                    더 불러오는 중...
+                  </div>
+                )}
+
+                {/* 더 이상 없을 때 */}
+                {!active.hasNextPage && list.length > 0 && (
+                  <div className="w-full text-center text-sm text-text-3">
+                    마지막 편지입니다.
+                  </div>
+                )}
+              </>
             )}
           </div>
         </DivBox>

--- a/src/components/dashboard/contents/main/third/YearlyLetterOverview.tsx
+++ b/src/components/dashboard/contents/main/third/YearlyLetterOverview.tsx
@@ -80,16 +80,21 @@ const data = [
 
 export default function YearlyLetterOverview() {
   /** 보낸 편지 */
-  const { data: sendList } = useQuery({
-    queryKey: ["capsuleDashboard", "send"],
-    queryFn: ({ signal }) => capsuleDashboardApi.sendDashboard(signal),
+  const { data: sendData } = useQuery({
+    queryKey: ["capsuleDashboard", "send", "count"],
+    queryFn: ({ signal }) =>
+      capsuleDashboardApi.sendDashboard({ page: 0, size: 1 }, signal),
   });
 
   /** 받은 편지 */
-  const { data: receiveList } = useQuery({
-    queryKey: ["capsuleDashboard", "receive"],
-    queryFn: ({ signal }) => capsuleDashboardApi.receiveDashboard(signal),
+  const { data: receiveData } = useQuery({
+    queryKey: ["capsuleDashboard", "receive", "count"],
+    queryFn: ({ signal }) =>
+      capsuleDashboardApi.receiveDashboard({ page: 0, size: 1 }, signal),
   });
+
+  const sendCount = sendData?.data.totalElements ?? 0;
+  const receiveCount = receiveData?.data.totalElements ?? 0;
 
   return (
     <>
@@ -107,11 +112,11 @@ export default function YearlyLetterOverview() {
         <div className="flex gap-4">
           <div className="w-full px-4 py-3 bg-sub rounded-[10px] space-y-2">
             <p className="text-sm">보낸 편지</p>
-            <p className="text-12 text-2xl">{sendList?.length ?? 0}</p>
+            <p className="text-12 text-2xl">{sendCount}</p>
           </div>
           <div className="w-full px-4 py-3 bg-primary-5 rounded-[10px] space-y-2">
             <p className="text-sm">받은 편지</p>
-            <p className="text-2xl">{receiveList?.length ?? 0}</p>
+            <p className="text-2xl">{receiveCount}</p>
           </div>
         </div>
         <div className="h-80 select-none outline-none [&_*:focus]:outline-none">

--- a/src/components/dashboard/sidebar/MyMailbox.tsx
+++ b/src/components/dashboard/sidebar/MyMailbox.tsx
@@ -19,26 +19,29 @@ export default function MyMailbox() {
     "bg-primary-2 border-primary-2/0 text-white shadow-md hover:bg-primary-2";
 
   /** 보낸 편지 */
-  const { data: sendList } = useQuery({
-    queryKey: ["capsuleDashboard", "send"],
-    queryFn: ({ signal }) => capsuleDashboardApi.sendDashboard(signal),
+  const { data: sendData } = useQuery({
+    queryKey: ["capsuleDashboard", "send", "count"],
+    queryFn: ({ signal }) =>
+      capsuleDashboardApi.sendDashboard({ page: 0, size: 1 }, signal),
   });
 
   /** 받은 편지 */
-  const { data: receiveList } = useQuery({
-    queryKey: ["capsuleDashboard", "receive"],
-    queryFn: ({ signal }) => capsuleDashboardApi.receiveDashboard(signal),
+  const { data: receiveData } = useQuery({
+    queryKey: ["capsuleDashboard", "receive", "count"],
+    queryFn: ({ signal }) =>
+      capsuleDashboardApi.receiveDashboard({ page: 0, size: 1 }, signal),
   });
 
   /* 북마크 */
-  const { data: bookmarkList } = useQuery({
-    queryKey: ["bookmarks", { page: 0, size: 10 }],
+  const { data: bookmarkData } = useQuery({
+    queryKey: ["bookmarks", "count"],
     queryFn: ({ signal }) =>
-      capsuleDashboardApi.bookmarks(
-        { page: 0, size: 10, sort: ["bookmarkedAt,desc"] },
-        signal
-      ),
+      capsuleDashboardApi.bookmarks({ page: 0, size: 1 }, signal),
   });
+
+  const sendCount = sendData?.data.totalElements ?? 0;
+  const receiveCount = receiveData?.data.totalElements ?? 0;
+  const bookmarkCount = bookmarkData?.totalElements ?? 0;
 
   return (
     <div className="space-y-3">
@@ -65,7 +68,7 @@ export default function MyMailbox() {
                 >
                   보낸 편지
                 </span>
-                <span className="text-2xl">{sendList?.length ?? 0}</span>
+                <span className="text-2xl">{sendCount}</span>
               </div>
             </div>
           </DivBox>
@@ -86,7 +89,7 @@ export default function MyMailbox() {
                 >
                   받은 편지
                 </span>
-                <span className="text-2xl">{receiveList?.length ?? 0}</span>
+                <span className="text-2xl">{receiveCount}</span>
               </div>
             </div>
           </DivBox>
@@ -107,9 +110,7 @@ export default function MyMailbox() {
                 >
                   소중한 편지
                 </span>
-                <span className="text-2xl">
-                  {bookmarkList?.totalElements ?? 0}
-                </span>
+                <span className="text-2xl">{bookmarkCount}</span>
               </div>
             </div>
           </DivBox>

--- a/src/components/dashboard/sidebar/Profile.tsx
+++ b/src/components/dashboard/sidebar/Profile.tsx
@@ -4,8 +4,6 @@ import DivBox from "../DivBox";
 import { useEffect, useState } from "react";
 import { getMeDetail, type MemberMeDetail } from "@/lib/api/members/members";
 
-
-
 export default function Profile({
   mode,
   onClick,
@@ -15,7 +13,7 @@ export default function Profile({
   onClick?: () => void;
   me?: MemberMeDetail | null;
 }) {
-  // ✅ props를 state로 복사하지 말기!
+  // props를 state로 복사하지 말기!
   // props가 없을 때만 fetch해서 state로 채움
   const [meFetched, setMeFetched] = useState<MemberMeDetail | null>(null);
 
@@ -70,5 +68,3 @@ export default function Profile({
     </button>
   );
 }
-
-

--- a/src/components/dashboard/sidebar/profile/ProfileModal.tsx
+++ b/src/components/dashboard/sidebar/profile/ProfileModal.tsx
@@ -208,7 +208,7 @@ export default function ProfileModal({
           <div className="py-4 px-6 flex justify-between items-center border-b border-outline">
             <h4 className="text-lg">내 프로필</h4>
 
-            {/* ✅ 구글 유저도 닫기는 허용(원하면 막을 수도 있음) */}
+            {/* 구글 유저도 닫기는 허용(원하면 막을 수도 있음) */}
             <button
               type="button"
               onClick={handleClose}

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -1,5 +1,12 @@
 import { apiFetchRaw } from "../fetchClient";
 
+const FAR_FUTURE_UNLOCK_UNTIL_ISO = "9999-12-31T23:59:59Z";
+
+function toIsoIfFilled(dayForm?: DayForm): string | undefined {
+  if (!dayForm?.date || !dayForm?.time) return undefined;
+  return new Date(`${dayForm.date}T${dayForm.time}:00`).toISOString();
+}
+
 type BuildCommonArgs = {
   memberId: number;
   senderName: string;
@@ -51,7 +58,7 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
     visibility,
     unlockType: effectiveUnlockType,
     unlockAt,
-    unlockUntil: new Date("9999-12-31T23:59:59Z").toISOString(),
+    unlockUntil: undefined,
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
@@ -113,12 +120,14 @@ export function buildPrivatePayload(
       ? new Date(`${dayForm.date}T${dayForm.time}:00`).toISOString()
       : undefined;
 
+  const expireIso = toIsoIfFilled(expireDayForm);
+
   const unlockUntil =
-    expireDayForm &&
     (effectiveUnlockType === "TIME" ||
-      effectiveUnlockType === "TIME_AND_LOCATION")
-      ? new Date(`${expireDayForm.date}T${expireDayForm.time}:00`).toISOString()
-      : new Date("9999-12-31T23:59:59Z").toISOString();
+      effectiveUnlockType === "TIME_AND_LOCATION") &&
+    expireIso
+      ? expireIso
+      : FAR_FUTURE_UNLOCK_UNTIL_ISO;
 
   return {
     memberId,
@@ -193,12 +202,14 @@ export function buildPublicPayload(
       ? new Date(`${dayForm.date}T${dayForm.time}:00`).toISOString()
       : undefined;
 
+  const expireIso = toIsoIfFilled(expireDayForm);
+
   const unlockUntil =
-    expireDayForm &&
     (effectiveUnlockType === "TIME" ||
-      effectiveUnlockType === "TIME_AND_LOCATION")
-      ? new Date(`${expireDayForm.date}T${expireDayForm.time}:00`).toISOString()
-      : new Date("9999-12-31T23:59:59Z").toISOString();
+      effectiveUnlockType === "TIME_AND_LOCATION") &&
+    expireIso
+      ? expireIso
+      : FAR_FUTURE_UNLOCK_UNTIL_ISO;
 
   return {
     memberId,

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -1,16 +1,4 @@
 import { apiFetchRaw } from "../fetchClient";
-import {
-  CapsuleCreateResponse,
-  CreatePrivateCapsuleRequest,
-  CreateMyCapsuleRequest,
-  CreatePublicCapsuleRequest,
-  CapsuleUpdateRequest,
-  CapsuleUpdateResponse,
-  CapsuleDeleteResponse,
-  CapsuleLikeResponse,
-  CapsuleSendReadResponse,
-  UnlockType,
-} from "./types";
 
 type BuildCommonArgs = {
   memberId: number;
@@ -63,7 +51,7 @@ export function buildMyPayload(args: BuildCommonArgs): CreateMyCapsuleRequest {
     visibility,
     unlockType: effectiveUnlockType,
     unlockAt,
-    unlockUntil: undefined,
+    unlockUntil: new Date("9999-12-31T23:59:59Z").toISOString(),
     locationName:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
@@ -118,6 +106,7 @@ export function buildPrivatePayload(
     packingColor = "",
     contentColor = "",
   } = args;
+
   const unlockAt =
     effectiveUnlockType === "TIME" ||
     effectiveUnlockType === "TIME_AND_LOCATION"
@@ -129,7 +118,7 @@ export function buildPrivatePayload(
     (effectiveUnlockType === "TIME" ||
       effectiveUnlockType === "TIME_AND_LOCATION")
       ? new Date(`${expireDayForm.date}T${expireDayForm.time}:00`).toISOString()
-      : undefined;
+      : new Date("9999-12-31T23:59:59Z").toISOString();
 
   return {
     memberId,
@@ -209,7 +198,7 @@ export function buildPublicPayload(
     (effectiveUnlockType === "TIME" ||
       effectiveUnlockType === "TIME_AND_LOCATION")
       ? new Date(`${expireDayForm.date}T${expireDayForm.time}:00`).toISOString()
-      : undefined;
+      : new Date("9999-12-31T23:59:59Z").toISOString();
 
   return {
     memberId,

--- a/src/lib/api/capsule/dashboardCapsule.ts
+++ b/src/lib/api/capsule/dashboardCapsule.ts
@@ -8,6 +8,11 @@ export const capsuleDashboardApi = {
     }),
 
   /* 보낸 편지 읽기 */
+  readSendCapsule: (capsuleId: number, signal?: AbortSignal) =>
+    apiFetch<CapsuleDashboardSendItem>(
+      `/api/v1/capsule/readSendCapsule?capsuleId=${capsuleId}`,
+      { signal }
+    ),
 
   /* 받은 편지 */
   receiveDashboard: (signal?: AbortSignal) =>

--- a/src/lib/api/capsule/dashboardCapsule.ts
+++ b/src/lib/api/capsule/dashboardCapsule.ts
@@ -45,6 +45,7 @@ export const capsuleDashboardApi = {
   addBookmark: (capsuleId: number, signal?: AbortSignal) =>
     apiFetch("/api/bookmarks", {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ capsuleId }),
       signal,
     }),

--- a/src/lib/api/capsule/dashboardCapsule.ts
+++ b/src/lib/api/capsule/dashboardCapsule.ts
@@ -2,10 +2,23 @@ import { apiFetch, apiFetchRaw } from "../fetchClient";
 
 export const capsuleDashboardApi = {
   /* 보낸 편지 */
-  sendDashboard: (signal?: AbortSignal) =>
-    apiFetch<CapsuleDashboardItem[]>("/api/v1/capsule/send/dashboard", {
-      signal,
-    }),
+  sendDashboard: (
+    params?: { page?: number; size?: number; sort?: string[] },
+    signal?: AbortSignal
+  ) => {
+    const page = params?.page ?? 0;
+    const size = params?.size ?? 10;
+
+    const sp = new URLSearchParams();
+    sp.set("page", String(page));
+    sp.set("size", String(size));
+    params?.sort?.forEach((s) => sp.append("sort", s));
+
+    return apiFetchRaw<PageResponse<CapsuleDashboardItem>>(
+      `/api/v1/capsule/send/dashboard?${sp.toString()}`,
+      { signal }
+    );
+  },
 
   /* 보낸 편지 읽기 */
   readSendCapsule: (capsuleId: number, signal?: AbortSignal) =>
@@ -15,10 +28,23 @@ export const capsuleDashboardApi = {
     ),
 
   /* 받은 편지 */
-  receiveDashboard: (signal?: AbortSignal) =>
-    apiFetch<CapsuleDashboardItem[]>("/api/v1/capsule/receive/dashboard", {
-      signal,
-    }),
+  receiveDashboard: (
+    params?: { page?: number; size?: number; sort?: string[] },
+    signal?: AbortSignal
+  ) => {
+    const page = params?.page ?? 0;
+    const size = params?.size ?? 10;
+
+    const sp = new URLSearchParams();
+    sp.set("page", String(page));
+    sp.set("size", String(size));
+    params?.sort?.forEach((s) => sp.append("sort", s));
+
+    return apiFetchRaw<PageResponse<CapsuleDashboardItem>>(
+      `/api/v1/capsule/receive/dashboard?${sp.toString()}`,
+      { signal }
+    );
+  },
 
   /* 북마크 편지 */
   bookmarks: (

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -1,6 +1,6 @@
-export type UnlockType = "TIME" | "LOCATION" | "TIME_AND_LOCATION";
+type UnlockType = "TIME" | "LOCATION" | "TIME_AND_LOCATION";
 
-export interface CreatePrivateCapsuleRequest {
+interface CreatePrivateCapsuleRequest {
   memberId: number;
   nickname: string;
   receiverNickname: string;
@@ -24,7 +24,7 @@ export interface CreatePrivateCapsuleRequest {
   capsulePackingColor?: string;
 }
 
-export interface CreateMyCapsuleRequest {
+interface CreateMyCapsuleRequest {
   memberId: number;
   nickname: string;
   receiverNickname: string;
@@ -44,7 +44,7 @@ export interface CreateMyCapsuleRequest {
   maxViewCount: number;
 }
 
-export interface CreatePublicCapsuleRequest {
+interface CreatePublicCapsuleRequest {
   memberId: number;
   nickname: string;
   title: string;
@@ -65,7 +65,7 @@ export interface CreatePublicCapsuleRequest {
   maxViewCount: number;
 }
 
-export interface CapsuleCreateResponse {
+interface CapsuleCreateResponse {
   memberId: number;
   capsuleId: number;
   nickname?: string;
@@ -82,30 +82,30 @@ export interface CapsuleCreateResponse {
   capPW?: string;
 }
 
-export interface CapsuleUpdateRequest {
+interface CapsuleUpdateRequest {
   title?: string;
   content?: string;
 }
 
-export interface CapsuleUpdateResponse {
+interface CapsuleUpdateResponse {
   message: string;
 }
 
-export interface CapsuleDeleteResponse {
+interface CapsuleDeleteResponse {
   capsuleId: number;
   message: string;
 }
 
-export interface CapsuleLikeRequest {
+interface CapsuleLikeRequest {
   capsuleId: number;
 }
 
-export interface CapsuleLikeResponse {
+interface CapsuleLikeResponse {
   likeCount: number;
   message: string;
 }
 
-export interface CapsuleSendReadResponse {
+interface CapsuleSendReadResponse {
   capsuleId: number;
   capsuleColor: string;
   capsulePackingColor: string;

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -113,7 +113,7 @@ interface CapsuleSendReadResponse {
   senderNickname: string;
   title: string;
   content: string;
-  createAt: string;
+  createdAt: string;
   viewStatus: boolean;
   unlockType: "TIME" | "LOCATION" | "TIME_AND_LOCATION";
   unlockAt: string;

--- a/src/type/capsule/dashboardCapsule.d.ts
+++ b/src/type/capsule/dashboardCapsule.d.ts
@@ -16,6 +16,27 @@ type CapsuleDashboardItem = {
   locationLng?: number | null;
 };
 
+type CapsuleDashboardSendItem = {
+  capsuleId: number;
+  capsuleColor: string;
+  capsulePackingColor: string;
+  recipient: string;
+  senderNickname: string;
+  title: string;
+  content: string;
+  createAt: string;
+  viewStatus: boolean;
+  unlockType: "TIME" | "LOCATION" | "TIME_AND_LOCATION";
+  unlockAt: string | null;
+  unlockUntil: string | null;
+  locationName: string | null;
+  locationLat: number | null;
+  locationLng: number | null;
+  locationRadiusM: number;
+  isBookmarked: boolean;
+  result: string;
+};
+
 /* 북마크 */
 type BookmarkItem = {
   bookmarkId: number;

--- a/src/type/capsule/dashboardCapsule.d.ts
+++ b/src/type/capsule/dashboardCapsule.d.ts
@@ -1,3 +1,36 @@
+type SortMeta = {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+};
+
+type PageableMeta = {
+  pageNumber: number;
+  pageSize: number;
+  sort: SortMeta;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+};
+
+type PageResponse<T> = {
+  code: string;
+  message: string;
+  data: {
+    content: T[];
+    pageable: PageableMeta;
+    last: boolean;
+    totalElements: number;
+    totalPages: number;
+    size: number;
+    number: number;
+    sort: SortMeta;
+    first: boolean;
+    numberOfElements: number;
+    empty: boolean;
+  };
+};
+
 /* 보낸, 받은 편지 조회 */
 type CapsuleDashboardItem = {
   capsuleId: number;
@@ -57,5 +90,3 @@ type BookmarkPageResponse = {
   totalElements: number;
   last: boolean;
 };
-
-/* 보낸 사람 조회 */

--- a/src/type/capsule/dashboardCapsule.d.ts
+++ b/src/type/capsule/dashboardCapsule.d.ts
@@ -57,7 +57,7 @@ type CapsuleDashboardSendItem = {
   senderNickname: string;
   title: string;
   content: string;
-  createAt: string;
+  createdAt: string;
   viewStatus: boolean;
   unlockType: "TIME" | "LOCATION" | "TIME_AND_LOCATION";
   unlockAt: string | null;

--- a/src/type/capsule/guestCapsule.d.ts
+++ b/src/type/capsule/guestCapsule.d.ts
@@ -27,7 +27,7 @@ type CapsuleReadData = {
   senderNickname: string;
   title: string;
   content: string;
-  createAt: string;
+  createdAt: string;
   viewStatus: boolean;
   unlockType: UnlockType;
   unlockAt: string;

--- a/src/type/letter.d.ts
+++ b/src/type/letter.d.ts
@@ -11,13 +11,13 @@ interface Capsule {
   from: string;
   to: string;
   title: string;
-  content: string; // ✅ 본문
-  createdAt: string; // ✅ 작성일(ISO)
+  content: string; // 본문
+  createdAt: string; // 작성일(ISO)
   unlockCondition: UnlockCondition;
   isUnlocked: boolean;
   isRead: boolean;
-  isBookmarked: boolean; // ✅ 저장하기 상태
-  sharePath: string; // ✅ 공개 링크 (/capsules/[id] 같은)
+  isBookmarked: boolean; // 저장하기 상태
+  sharePath: string; // 공개 링크
 }
 
 interface PublicCapsule {


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요
1. 보낸 편지
- 잠금 해제 조건이 충족되지 않아도 조회 가능하도록 UI 수정
- 보낸 편지 전용 조회 api 연결 후 조회 가능
- 기존에 해제 조건 완료 여부에서 viewStatus를 통해서 상대방 확인 여부에 따라 수정 가능 여부로 수정 

2. 받은 편지
- 위치 조건일 경우,  실제 조회 검증 api는 있는데 현재 UI 상태로 보여줄 수 있는 방법이 없어서 해제 조건이 됐는지 검증하는 로직이 없어서 추가

3. 저장, 북마크
- 저장 및 북마크 분기 처리
- 완료 모달 연결
- 북마크 등록 버그 수정

4. 비회원 조회 한 번 더 확인
- 시간 => 확인
- 위치 => 확인
- 시간 + 위치 => 확인

5. 편지 봉투 색상 및 편지지 색상
- 색상 적용 완료
- 데이터가 비어있을 경우를 대비해서 기본 색상 적용(베이지)

6. 보낸, 받은 편지 수정된 api 변경
- api 수정 후 연결
- 무한 스크롤링 페이지 구현
<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] Task

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="1358" height="380" alt="image" src="https://github.com/user-attachments/assets/b0367b83-93ea-4483-822c-398222a005ce" />
<img width="1355" height="377" alt="image" src="https://github.com/user-attachments/assets/f250c8b4-77b1-49e5-9a7f-7ffa7275f629" />
<img width="1227" height="889" alt="image" src="https://github.com/user-attachments/assets/7612d768-825b-4dd1-a7d4-c5c48a5d3bac" />

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
