### PR TITLE
[#84] feat(storytrack-create): 스토리트랙 생성을 위한 API 타입 정의 및 호출 함수 구현

### DIFF
--- a/src/lib/api/dashboard/storyTrack.ts
+++ b/src/lib/api/dashboard/storyTrack.ts
@@ -35,4 +35,26 @@ export const storyTrackApi = {
       }
     );
   },
+
+  /**
+   * 내가 만든 장소 기반 공개 캡슐 목록 조회 (스토리트랙 생성용)
+   * 장소 기반(LOCATION), 장소+시간 기반(TIME_AND_LOCATION) 공개 캡슐이 조회됩니다.
+   * @param params 페이지네이션 파라미터
+   */
+  getCapsuleList: (
+    params?: { page?: number; size?: number },
+    signal?: AbortSignal
+  ) => {
+    const page = params?.page ?? 0;
+    const size = params?.size ?? 10;
+
+    const sp = new URLSearchParams();
+    sp.set("page", String(page));
+    sp.set("size", String(size));
+
+    return apiFetchRaw<PageResponse<CapsuleDashboardItem>>(
+      `/api/v1/storytrack/creater/capsuleList?${sp.toString()}`,
+      { signal }
+    );
+  },
 };

--- a/src/lib/api/dashboard/storyTrack.ts
+++ b/src/lib/api/dashboard/storyTrack.ts
@@ -17,4 +17,22 @@ export const storyTrackApi = {
       { signal }
     );
   },
+
+  /**
+   * 스토리트랙 생성 API 호출
+   * @param payload 스토리트랙 생성 요청 데이터
+   */
+  createStorytrack: (
+    payload: CreateStorytrackRequest,
+    signal?: AbortSignal
+  ) => {
+    return apiFetchRaw<ApiResponse<CreateStorytrackResponse>>(
+      "/api/v1/storytrack/creat",
+      {
+        method: "POST",
+        json: payload,
+        signal,
+      }
+    );
+  },
 };

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -38,3 +38,25 @@ type StoryTrackListPage = {
 };
 
 type StoryTrackListResponse = ApiResponse<StoryTrackListPage>;
+
+/* 스토리트랙 생성 요청 */
+type CreateStorytrackRequest = {
+  title: string;
+  description: string;
+  trackType: "SEQUENTIAL" | "FREE";
+  isPublic: number; // 0: 비공개, 1: 공개
+  price: number;
+  capsuleList: number[]; // capsuleId 배열
+};
+
+/* 스토리트랙 생성 응답 */
+type CreateStorytrackResponse = {
+  storytrackId: number;
+  title: string;
+  description: string;
+  trackType: "SEQUENTIAL" | "FREE";
+  isPublic: number;
+  price: number;
+  totalSteps: number;
+  capsuleList: number[]; // capsuleId 배열
+};


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

스토리트랙 생성 기능 구현을 위한 API 타입 정의와 API 호출 함수를 구현

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #84 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] `CreateStorytrackRequest` 타입 정의 추가 (`src/type/storyTrack.d.ts`)
- [x] `CreateStorytrackResponse` 타입 정의 추가 (`src/type/storyTrack.d.ts`)
- [x] `createStorytrack()` API 함수 구현 (`src/lib/api/dashboard/storyTrack.ts`)
- [x] `getCapsuleList()` API 함수 구현 (`src/lib/api/dashboard/storyTrack.ts`)

## 📝 변경 사항

### 타입 정의
- **CreateStorytrackRequest**: 스토리트랙 생성 요청 타입
  - `title`, `description`, `trackType` ("SEQUENTIAL" | "FREE")
  - `isPublic`, `price`, `capsuleList` (number[])
  
- **CreateStorytrackResponse**: 스토리트랙 생성 응답 타입
  - 생성된 스토리트랙 정보 및 `storytrackId` 포함

### API 함수
- **createStorytrack()**: `POST /api/v1/storytrack/creat` 호출
- **getCapsuleList()**: `GET /api/v1/storytrack/creater/capsuleList` 호출
  - 페이지네이션 지원 (page, size)
  - `PageResponse<CapsuleDashboardItem>` 반환 (기존 타입 재사용)

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

_N/A_

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- 타입 정의가 백엔드 DTO와 일치하는지 확인 부탁드립니다.
- API 함수의 파라미터 및 반환 타입이 올바른지 확인 부탁드립니다.
- `trackType` 유니온 타입 ("SEQUENTIAL" | "FREE")이 적절한지 확인 부탁드립니다.

