### PR TITLE
fix(public): 공개 캡슐 생성 시 viewingRadius 필드가 0으로 전달되던 문제 수정

### DIFF
--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -243,7 +243,7 @@ export function buildPublicPayload(
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.lng ?? 0
         : 0,
-    viewingRadius:
+    locationRadiusM:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.viewingRadius

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -243,10 +243,10 @@ export function buildPublicPayload(
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.lng ?? 0
         : 0,
-    locationRadiusM:
+    viewingRadius:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
-        ? 500
+        ? locationForm.viewingRadius
         : 0,
     maxViewCount: 0,
   };

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -243,6 +243,11 @@ export function buildPublicPayload(
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.lng ?? 0
         : 0,
+    locationRadiusM:
+      effectiveUnlockType === "LOCATION" ||
+      effectiveUnlockType === "TIME_AND_LOCATION"
+        ? 500
+        : 0,
     maxViewCount: 0,
   };
 }

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -243,12 +243,13 @@ export function buildPublicPayload(
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.lng ?? 0
         : 0,
-    locationRadiusM:
+    viewingRadius:
       effectiveUnlockType === "LOCATION" ||
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.viewingRadius
         : 0,
     maxViewCount: 0,
+    attachmentIds: [], // 첨부 파일은 추후 구현
   };
 }
 

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -62,7 +62,7 @@ interface CreatePublicCapsuleRequest {
   address?: string;
   locationLat: number;
   locationLng: number;
-  locationRadiusM: number; // 공개 캡슐은 locationRadiusM 사용
+  viewingRadius: number; // 공개/비공개 모두 viewingRadius로 통일
   maxViewCount: number;
 }
 

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -62,8 +62,9 @@ interface CreatePublicCapsuleRequest {
   address?: string;
   locationLat: number;
   locationLng: number;
-  locationRadiusM: number;
+  viewingRadius: number;
   maxViewCount: number;
+  attachmentIds?: number[]; // 첨부 파일 ID 목록
 }
 
 interface CapsuleCreateResponse {

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -62,7 +62,7 @@ interface CreatePublicCapsuleRequest {
   address?: string;
   locationLat: number;
   locationLng: number;
-  viewingRadius: number;
+  locationRadiusM: number;
   maxViewCount: number;
   attachmentIds?: number[]; // 첨부 파일 ID 목록
 }

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -62,7 +62,7 @@ interface CreatePublicCapsuleRequest {
   address?: string;
   locationLat: number;
   locationLng: number;
-  viewingRadius: number; // 공개/비공개 모두 viewingRadius로 통일
+  locationRadiusM: number;
   maxViewCount: number;
 }
 

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -62,6 +62,7 @@ interface CreatePublicCapsuleRequest {
   address?: string;
   locationLat: number;
   locationLng: number;
+  locationRadiusM: number; // 공개 캡슐은 locationRadiusM 사용
   maxViewCount: number;
 }
 

--- a/src/type/newCapsule.d.ts
+++ b/src/type/newCapsule.d.ts
@@ -9,7 +9,7 @@ type LocationForm = {
   query: string; // 사용자가 검색창에 입력한 값
   placeName: string; // 선택된 장소명(최종)
   locationLabel: string; // 사용자가 붙이는 장소 별칭(전송값)
-  viewingRadius: 50; // 조회 반경(m)
+  viewingRadius: number; // 조회 반경(m)
   address?: string; // 선택된 주소(선택)
   lat?: number; // 좌표(선택)
   lng?: number; // 좌표(선택)


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

공개 캡슐 생성 시 `viewingRadius` 필드가 0으로 전달되던 문제를 수정하고, API 스펙에 맞춰 `locationRadiusM` 필드를 추가했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] `CreatePublicCapsuleRequest` 타입에 `locationRadiusM` 필드 추가
- [x] `buildPublicPayload` 함수에서 `locationRadiusM` 필드 추가
- [x] 공개 캡슐 생성 시 `locationForm.viewingRadius` 값 사용 (기본값 50에서 사용자 입력값으로 변경 가능)

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

_N/A_

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- 공개 캡슐 조회가 안되는 버그 디버깅 중 발견한 사항입니다.

- request시 DTO는 locationRadiusM이며, response시 DTO는 viewingRadius입니다.

- 공개 캡슐 생성 시 `viewingRadius` 값이 올바르게 전달되는지 확인 부탁드립니다.

- `src/components/capsule/new/left/WriteForm.tsx` 에서 아래부분의 viewingRadius를 수정하여 반경을 수정할 수 있습니다/
  const [locationForm, setLocationForm] = useState<LocationForm>({
    query: "",
    placeName: "",
    locationLabel: "",
    viewingRadius: 50,
    address: "",
    lat: undefined,
    lng: undefined,
  });

