### PR TITLE
[#89] feat(storytrack-list):스토리 트랙 조회

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,6 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "cdn.pixabay.com",
-        port: "",
         pathname: "/**",
       },
     ],

--- a/src/components/dashboard/storyTrack/all/AllTrackPage.tsx
+++ b/src/components/dashboard/storyTrack/all/AllTrackPage.tsx
@@ -11,59 +11,27 @@ type StatusFilter = "all" | "active" | "ended";
 type SortOption = "newest" | "popular";
 
 export default function AllTrackPage() {
-  /* const tracks: StoryTrackItem[] = [
-    {
-      storytrackId: 1,
-      createrName: "홍길동",
-      title: "테스트 스토리트랙",
-      desctiption: "SEQUENTIAL 테스트",
-      trackType: "SEQUENTIAL",
-      isPublic: 1,
-      price: 0,
-      totalSteps: 3,
-      totalParticipant: 12,
-      createdAt: "2025-12-21",
-    },
-    {
-      storytrackId: 2,
-      createrName: "테스터123",
-      title: "테스트123213 스토리트랙",
-      desctiption: "자유 테스트",
-      trackType: "FREE",
-      isPublic: 1,
-      price: 0,
-      totalSteps: 2,
-      totalParticipant: 5,
-      createdAt: "2025-12-19",
-    },
-  ]; */
-
-  const page = 0;
+  const [page, setPage] = useState(0);
   const size = 10;
 
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState<StatusFilter>("all");
   const [sort, setSort] = useState<SortOption>("newest");
 
-  const {
-    data: tracks,
-    isLoading,
-    isError,
-    error,
-    refetch,
-  } = useQuery({
+  const { data: tracks, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["allStoryTrack", page, size],
     queryFn: async ({ signal }) => {
       return await storyTrackApi.allList({ page, size }, signal);
     },
   });
 
+  const pageInfo = tracks?.data;
+  const content = pageInfo?.content ?? [];
+
   return (
     <div className="p-8 space-y-6">
-      {/* Top */}
       <div className="space-y-3 flex-none">
         <BackButton />
-
         <div className="space-y-2">
           <h3 className="text-3xl font-medium">
             공개 스토리트랙 둘러보기
@@ -75,7 +43,6 @@ export default function AllTrackPage() {
         </div>
       </div>
 
-      {/* 검색 */}
       <div className="relative w-full">
         <Search
           size={20}
@@ -90,7 +57,6 @@ export default function AllTrackPage() {
         />
       </div>
 
-      {/* 로딩/에러 */}
       {isLoading && (
         <div className="rounded-xl border border-outline bg-white/80 p-6 text-text-2">
           불러오는 중...
@@ -101,7 +67,8 @@ export default function AllTrackPage() {
         <div className="rounded-xl border border-outline bg-white/80 p-6">
           <p className="text-primary font-medium">불러오기에 실패했어요.</p>
           <pre className="mt-3 text-xs whitespace-pre-wrap text-text-3">
-            {String(error?.message ?? error)}
+            {error instanceof Error ? error.message : String(error)}
+
           </pre>
           <button
             className="mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
@@ -113,9 +80,7 @@ export default function AllTrackPage() {
         </div>
       )}
 
-      {/* 필터 바 */}
       <div className="flex flex-wrap items-center gap-2">
-        {/* 상태 */}
         <div className="flex gap-2">
           <button
             onClick={() => setStatus("all")}
@@ -151,7 +116,6 @@ export default function AllTrackPage() {
 
         <div className="flex-1" />
 
-        {/* 정렬 */}
         <div className="relative">
           <select
             value={sort}
@@ -162,14 +126,12 @@ export default function AllTrackPage() {
             <option value="popular">인기순</option>
           </select>
 
-          {/* chevron */}
           <ChevronDown
             size={18}
             className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-4"
           />
         </div>
 
-        {/* 초기화 */}
         <button
           onClick={() => {
             setSearch("");
@@ -182,20 +144,45 @@ export default function AllTrackPage() {
         </button>
       </div>
 
-      {/* List */}
-      {/* 로딩/에러 아닐 때만 리스트 영역 보여주면 UX도 좋아짐 */}
       {!isLoading && !isError && (
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {tracks!.data.content.map((t) => (
-            <TrackCard key={t.storytrackId} track={t} />
-          ))}
+        <>
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {content.map((t) => (
+             <TrackCard key={t.storytrackId} track={t} />
+           ))}
 
-          {tracks!.data.content.length === 0 && (
-            <div className="col-span-full text-center text-text-3 py-12">
-              조건에 맞는 트랙이 없어요.
-            </div>
-          )}
-        </div>
+
+            {content.length === 0 && (
+              <div className="col-span-full text-center text-text-3 py-12">
+                조건에 맞는 트랙이 없어요.
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-center gap-3 pt-4">
+            <button
+              className="px-3 py-2 rounded-xl border border-outline text-text-2 disabled:opacity-40"
+              disabled={page === 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              type="button"
+            >
+              이전
+            </button>
+
+            <span className="text-text-2">
+              {page + 1} / {pageInfo?.totalPages ?? 1}
+            </span>
+
+            <button
+              className="px-3 py-2 rounded-xl border border-outline text-text-2 disabled:opacity-40"
+              disabled={pageInfo?.last ?? true}
+              onClick={() => setPage((p) => p + 1)}
+              type="button"
+            >
+              다음
+            </button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/dashboard/storyTrack/all/AllTrackPage.tsx
+++ b/src/components/dashboard/storyTrack/all/AllTrackPage.tsx
@@ -18,7 +18,13 @@ export default function AllTrackPage() {
   const [status, setStatus] = useState<StatusFilter>("all");
   const [sort, setSort] = useState<SortOption>("newest");
 
-  const { data: tracks, isLoading, isError, error, refetch } = useQuery({
+  const {
+    data: tracks,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ["allStoryTrack", page, size],
     queryFn: async ({ signal }) => {
       return await storyTrackApi.allList({ page, size }, signal);
@@ -68,7 +74,6 @@ export default function AllTrackPage() {
           <p className="text-primary font-medium">불러오기에 실패했어요.</p>
           <pre className="mt-3 text-xs whitespace-pre-wrap text-text-3">
             {error instanceof Error ? error.message : String(error)}
-
           </pre>
           <button
             className="mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
@@ -146,11 +151,10 @@ export default function AllTrackPage() {
 
       {!isLoading && !isError && (
         <>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid md:grid-cols-3 lg:grid-cols-5 gap-6">
             {content.map((t) => (
-             <TrackCard key={t.storytrackId} track={t} />
-           ))}
-
+              <TrackCard key={t.storytrackId} track={t} />
+            ))}
 
             {content.length === 0 && (
               <div className="col-span-full text-center text-text-3 py-12">

--- a/src/components/dashboard/storyTrack/all/TrackCard.tsx
+++ b/src/components/dashboard/storyTrack/all/TrackCard.tsx
@@ -51,7 +51,7 @@ export default function TrackCard({ track }: { track: StoryTrackItem }) {
             <div className="flex gap-1 items-center">
               <Users size={16} />
               {/* 나중에 참여자 수 추가하면 */}
-              {track.totalParticipant ?? 0}명
+              {track.totalMemberCount ?? 0}명
             </div>
           </div>
 

--- a/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
@@ -3,13 +3,16 @@
 import { useState } from "react";
 import BackButton from "@/components/common/BackButton";
 import TrackHeader from "./TrackHeader";
-import TrackTabMenu from "./TrackTabMenu";
 import TrackOverview from "./TrackOverview";
-import TrackRoute from "./TrackRoute";
 import TrackProgress from "./TrackProgress";
+import TrackTabMenu from "./TrackTabMenu";
+import TrackRoute from "./TrackRoute";
+import TrackMap from "./TrackMap";
+
+type TabType = "route" | "map";
 
 export default function TrackDetailPage() {
-  const [tab, setTab] = useState<"overview" | "route" | "progress">("overview");
+  const [tab, setTab] = useState<TabType>("route");
 
   return (
     <div className="h-screen flex flex-col p-8 gap-8">
@@ -17,19 +20,35 @@ export default function TrackDetailPage() {
         <BackButton />
       </div>
 
-      <div className="flex-1 min-h-0 border border-outline rounded-2xl overflow-hidden flex flex-col">
-        {/* Header */}
-        <TrackHeader />
+      <div className="flex-1 min-h-0 overflow-hidden flex gap-6">
+        {/* Left */}
+        <div className="flex-1 min-w-80 flex flex-col h-full gap-6 min-h-0">
+          <div className="border border-outline rounded-2xl">
+            <TrackHeader />
+          </div>
+          <div className="border border-outline rounded-2xl flex-1 min-h-0 overflow-hidden">
+            <TrackOverview />
+          </div>
+        </div>
 
-        {/* Menu */}
-        <TrackTabMenu activeTab={tab} onChange={setTab} />
+        {/* Right */}
+        <div className="flex-3 flex flex-col gap-6 min-h-0">
+          {/* Top */}
+          <div className="border border-outline rounded-2xl overflow-hidden">
+            <TrackProgress />
+          </div>
 
-        {/* Contents */}
-        <div className="flex-1 overflow-auto">
-          {tab === "overview" && <TrackOverview />}
-          {tab === "route" && <TrackRoute />}
-          {/* 작성자라면 이 탭도 보이지 않도록 처리 */}
-          {tab === "progress" && <TrackProgress />}
+          {/* Bottom */}
+          <div className="border border-outline rounded-2xl flex-1 min-h-0 overflow-hidden flex flex-col">
+            {/* 탭 메뉴 */}
+            <TrackTabMenu activeTab={tab} onChange={setTab} />
+
+            {/* 탭 컨텐츠 */}
+            <div className="flex-1 min-h-0 overflow-auto p-6">
+              {tab === "route" && <TrackRoute />}
+              {tab === "map" && <TrackMap />}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/dashboard/storyTrack/detail/TrackHeader.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackHeader.tsx
@@ -1,47 +1,14 @@
-import { ListOrdered, MapPin, Users } from "lucide-react";
 import Image from "next/image";
 
 export default function TrackHeader() {
   return (
-    <div className="relative w-full pt-20 pb-8 px-8 rounded-t-2xl overflow-hidden">
+    <div className="relative w-full h-64 pb-8 px-8 rounded-2xl overflow-hidden">
       <Image
-        src=""
+        src="https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"
         alt="대표 이미지"
         fill
-        className="object-cover bg-amber-200 z-0"
+        className="object-cover"
       />
-
-      <div className="absolute inset-0 bg-black/30 z-10" />
-
-      <div className="relative z-20 space-y-4">
-        <h4 className="text-3xl text-white font-semibold">서울 한강 이야기</h4>
-
-        <div className="text-white text-sm flex gap-3">
-          <div className="flex gap-1 items-center">
-            <ListOrdered size={16} />
-            순서대로
-          </div>
-          <div className="flex gap-1 items-center">
-            <MapPin size={16} />
-            5개 장소
-          </div>
-          <div className="flex gap-1 items-center">
-            <Users size={16} />
-            123명 참여 중
-          </div>
-        </div>
-
-        {/* Progress bar */}
-        <div className="space-y-2 p-3 rounded-lg bg-white/20">
-          <div className="flex justify-between text-xs text-white">
-            <span>진행 상황</span>
-            <span>2 / 5 완료</span>
-          </div>
-          <div className="relative w-full h-2 bg-button-hover rounded-full overflow-hidden">
-            <div className="absolute inset-0 w-[40%] bg-primary-2 rounded-full" />
-          </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/dashboard/storyTrack/detail/TrackMap.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackMap.tsx
@@ -1,0 +1,11 @@
+export default function TrackMap() {
+  return (
+    <>
+      <div className="h-full flex flex-col gap-4">
+        <div className="flex-1 flex gap-4 min-h-0">
+          <div className="w-full h-full overflow-y-auto space-y-4 pr-2"></div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/dashboard/storyTrack/detail/TrackOverview.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackOverview.tsx
@@ -1,39 +1,73 @@
-import { Pencil, Trash2, X } from "lucide-react";
+import { ListOrdered, Route, Users, X } from "lucide-react";
 
 export default function TrackOverview() {
   return (
     <>
-      <div className="p-8 flex flex-col h-full">
-        <div className="flex-1 min-h-0 space-y-6">
-          {/* 소개 내용 */}
-          <div className="space-y-4">
-            <p className="text-xl">트랙 소개</p>
-            <p className="text-text-3">
-              한강을 따라 펼쳐지는 추억의 여정. 여의도부터 뚝섬까지, 각 장소마다
-              숨겨진 이야기를 발견하세요. 이 스토리트랙은 한강의 아름다운 풍경과
-              함께 서울의 현대사가 담긴 특별한 장소들을 탐방합니다. 각 지점마다
-              준비된 편지를 통해 그 장소만의 이야기를 만나보세요.
-            </p>
+      <div className="p-6 flex flex-col h-full">
+        <div className="flex flex-col justify-between h-full">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              {/* 제목 */}
+              <div className="text-xl">서울 한강 이야기</div>
+              {/* 요약 */}
+              <div className="flex gap-2">
+                <div className="bg-primary-5/60 border-2 border-primary-4 rounded-full px-2 py-1 flex items-center gap-1 text-primary-2">
+                  <ListOrdered size={16} />
+                  <span className="text-sm">순서대로</span>
+                  {/* <Shuffle size={18} />
+                  <span>순서무관</span> */}
+                </div>
+
+                <div className="bg-button-hover border-2 border-outline rounded-full px-2 flex items-center gap-1 text-text-2">
+                  <Route size={16} />
+                  <span className="text-sm">5개 장소</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-1 text-text-3">
+                <Users size={16} />
+                <span className="text-sm">123명 참여 중</span>
+              </div>
+            </div>
+
+            {/* 구분선 */}
+            <div className="w-full h-px bg-outline"></div>
+
+            {/* 소개 */}
+            <div className="space-y-4">
+              {/* 소개 내용 */}
+              <div className="text-sm space-y-2">
+                <p>트랙 소개</p>
+                <p className="text-text-3 break-keep">
+                  한강을 따라 펼쳐지는 추억의 여정. 여의도부터 뚝섬까지, 각
+                  장소마다 숨겨진 이야기를 발견하세요. 이 스토리트랙은 한강의
+                  아름다운 풍경과 함께 서울의 현대사가 담긴 특별한 장소들을
+                  탐방합니다. 각 지점마다 준비된 편지를 통해 그 장소만의
+                  이야기를 만나보세요.
+                </p>
+              </div>
+
+              {/* 작성자 */}
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-black flex items-center justify-center text-white">
+                  홍
+                </div>
+                <div className="flex flex-col">
+                  {/* <span className="text-sm text-text-4">만든 사람</span> */}
+                  <span>홍길동</span>
+                </div>
+              </div>
+            </div>
+
+            {/* 구분선 */}
+            <div className="w-full h-px bg-outline"></div>
+
+            {/* 생성일 */}
+            <span className="text-text-3">생성일: 2025.12.01</span>
           </div>
 
-          {/* 작성자 */}
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-black flex items-center justify-center text-white">
-              홍
-            </div>
-            <div className="flex flex-col">
-              {/* <span className="text-sm text-text-4">만든 사람</span> */}
-              <span>홍길동</span>
-            </div>
-          </div>
-
-          {/* 생성일 */}
-          <span className="text-text-3">생성일: 2025.12.01</span>
-        </div>
-
-        {/* 버튼 */}
-        <div className="flex-none flex justify-end">
-          {/* <button className="cursor-pointer bg-text-2 hover:bg-text-3 text-white px-4 py-2 rounded-xl flex items-center gap-2">
+          {/* 버튼 */}
+          <div className="w-full">
+            {/* <button className="cursor-pointer bg-text-2 hover:bg-text-3 text-white px-4 py-2 rounded-xl flex items-center gap-2">
             <Pencil />
             수정
           </button>
@@ -41,10 +75,11 @@ export default function TrackOverview() {
             <Trash2 />
             삭제
           </button> */}
-          <button className="cursor-pointer bg-primary hover:bg-primary-3 text-white px-4 py-2 rounded-xl flex items-center gap-2">
-            <X />
-            참여 중지
-          </button>
+            <button className="w-full flex items-center justify-center gap-2 cursor-pointer bg-primary hover:bg-primary-3 text-white px-4 py-3 rounded-xl ">
+              <X />
+              참여 중지
+            </button>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/dashboard/storyTrack/detail/TrackProgress.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackProgress.tsx
@@ -1,55 +1,103 @@
-import { Flag } from "lucide-react";
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Flag } from "lucide-react";
 
 export default function TrackProgress() {
+  const [collapsed, setCollapsed] = useState(true);
+
+  const completed = 2;
+  const total = 5;
+  const percent = Math.round((completed / total) * 100);
+
   return (
-    <>
-      <div className="p-8 h-full flex flex-col gap-4">
-        <p className="flex-none text-xl">내 진행 상황</p>
-
-        <div className="flex-1 min-h-0 flex flex-col gap-6">
-          {/* 내가 완료한 장소 / 남은 장소 / 진행률 */}
-          <div className="flex gap-8">
-            <div className="flex-1 flex flex-col gap-2 p-6 border border-outline rounded-xl">
-              <span className="text-sm text-text-3">완료한 장소</span>
-              <span className="text-2xl">2</span>
-            </div>
-            <div className="flex-1 flex flex-col gap-2 p-6 border border-outline rounded-xl">
-              <span className="text-sm text-text-3">남은 장소</span>
-              <span className="text-2xl">3</span>
-            </div>
-            <div className="flex-1 flex flex-col gap-2 p-6 border border-outline rounded-xl">
-              <span className="text-sm text-text-3">진행률</span>
-              <span className="text-2xl">40%</span>
-            </div>
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div
+        className={`p-6  border-outline ${
+          collapsed ? "border-none" : "border-b"
+        }`}
+      >
+        <div className="flex justify-between items-center">
+          <div className="flex-none text-xl flex items-center gap-2">
+            <span>진행 상황</span>
+            <span className="text-sm text-primary-2">{percent}% 완료</span>
           </div>
 
-          {/* 다음 목적지 */}
-          <div className="flex flex-col gap-4 p-6 border border-outline rounded-xl">
-            <div className="flex items-center gap-2">
-              <Flag className="text-primary" />
-              <span className="text-lg">다음 목적지</span>
+          <div className="flex items-center gap-2">
+            <div className="w-32 h-1.5 bg-outline rounded-full overflow-hidden">
+              <div
+                className="h-full bg-primary-2"
+                style={{ width: `${(completed / total) * 100}%` }}
+              />
             </div>
-            <div className="space-y-2">
-              <p className="text-xl">잠심 한강 공원</p>
-              <p className="text-text-3 text-sm">
-                서울특별시 송파구 올림픽로 139
-              </p>
-            </div>
-          </div>
 
-          {/* 시작일 / 최근 방문일 */}
-          <div className="flex gap-8">
-            <div className="flex-1 flex flex-col gap-2 p-6 border border-outline rounded-xl">
-              <span className="text-sm text-text-3">시작일</span>
-              <span>2025. 12. 20.</span>
+            <button
+              type="button"
+              onClick={() => setCollapsed((v) => !v)}
+              className="cursor-pointer p-1 rounded-lg hover:bg-outline/40"
+              aria-expanded={!collapsed}
+              aria-label={collapsed ? "펼치기" : "접기"}
+            >
+              {collapsed ? <ChevronDown size={24} /> : <ChevronUp size={24} />}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Body (collapsible) */}
+      <div
+        className={[
+          "grid transition-all duration-200 ease-out",
+          collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
+        ].join(" ")}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="space-y-4 p-6">
+            {/* 경로 */}
+            <div className="flex gap-4">
+              <div className="flex-1 border border-outline rounded-xl p-4 flex flex-col gap-1">
+                <span className="text-xs text-text-3">완료한 장소</span>
+                <span className="text-xl">{completed}</span>
+              </div>
+              <div className="flex-1 border border-outline rounded-xl p-4 flex flex-col gap-1">
+                <span className="text-xs text-text-3">남은 장소</span>
+                <span className="text-xl">{total - completed}</span>
+              </div>
+              <div className="flex-1 border border-outline rounded-xl p-4 flex flex-col gap-1">
+                <span className="text-xs text-text-3">전체 장소</span>
+                <span className="text-xl">{total}</span>
+              </div>
             </div>
-            <div className="flex-1 flex flex-col gap-2 p-6 border border-outline rounded-xl">
-              <span className="text-sm text-text-3">최근 방문</span>
-              <span>2025. 12. 21.</span>
+
+            {/* 다음 목적지 */}
+            <div className="w-full border border-outline rounded-xl p-4 space-y-2">
+              <div className="flex items-center gap-2">
+                <Flag size={20} className="text-primary" />
+                <span>다음 목적지</span>
+              </div>
+              <div className="space-y-1">
+                <p className="text-lg">잠실 한강공원</p>
+                <p className="text-sm text-text-3">
+                  서울특별시 송파구 올림픽로 139
+                </p>
+              </div>
+            </div>
+
+            {/* 시작일 / 최근 방문 */}
+            <div className="w-full border border-outline rounded-xl p-4 flex">
+              <div className="flex-1 flex flex-col gap-0.5">
+                <span className="text-text-3 text-sm">시작일</span>
+                <span>2024. 12. 20</span>
+              </div>
+              <div className="flex-1 flex flex-col gap-0.5">
+                <span className="text-text-3 text-sm">최근 방문</span>
+                <span>2024. 12. 21</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
@@ -1,122 +1,75 @@
 import Logo from "@/components/common/Logo";
+import { Check, CheckCircle } from "lucide-react";
 
 export default function TrackRoute() {
   return (
-    <div className="p-8 h-full flex flex-col gap-4">
+    <div className="h-full flex flex-col gap-4">
       <p className="text-xl">경로 상세</p>
 
       <div className="flex-1 flex gap-4 min-h-0">
-        {/* Left - 편지들 (여기만 스크롤) */}
-        <div className="flex-1 min-h-0">
-          <div className="h-full overflow-y-auto space-y-4 pr-2">
-            {/* 순서대로 => 번호 / 순서x => 로고 */}
-            {/* 순서 버전 */}
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                1
-              </div>
-              <div>
-                <p className="text-lg">잠실 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 송파구 올림픽로 139
-                </p>
-              </div>
+        <div className="w-full h-full overflow-y-auto space-y-4 pr-2">
+          {/* 순서대로 => 번호 / 순서x => 로고 */}
+          {/* 순서 버전 */}
+          <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
+            <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+              1
             </div>
-
-            {/* 순서x 버전 */}
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                <Logo className="text-white w-8 h-8" />
-              </div>
-              <div>
-                <p className="text-lg">잠실 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 송파구 올림픽로 139
-                </p>
-              </div>
+            <div className="flex flex-col items-start">
+              <p className="text-lg">잠실 한강공원</p>
+              <p className="text-sm text-text-2">
+                서울특별시 송파구 올림픽로 139
+              </p>
             </div>
+          </button>
 
-            {/* 순서 버전 */}
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                2
-              </div>
-              <div>
+          {/* 순서x 버전 */}
+          <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
+            <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+              <Logo className="text-white w-6 h-6" />
+            </div>
+            <div className="flex flex-col items-start">
+              <p className="text-lg">잠실 한강공원</p>
+              <p className="text-sm text-text-2">
+                서울특별시 송파구 올림픽로 139
+              </p>
+            </div>
+          </button>
+
+          {/* 편지 확인 버전 */}
+          <button className="cursor-pointer w-full rounded-xl border border-green-400 p-6 flex items-start gap-4 bg-green-50">
+            <div className="w-12 h-12 rounded-full flex items-center justify-center bg-green-600 text-white">
+              <CheckCircle />
+            </div>
+            <div className="space-y-2">
+              <div className="flex flex-col items-start">
                 <p className="text-lg">뚝섬 한강공원</p>
                 <p className="text-sm text-text-2">
                   서울특별시 광진구 강변북로 139
                 </p>
               </div>
+              <p className="flex gap-1 text-xs text-green-600">
+                <Check size={16} />
+                <span>완료: 2024. 12. 21. 오전 10:15:00</span>
+              </p>
             </div>
+          </button>
 
-            {/* 순서x 버전 */}
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                <Logo className="text-white w-8 h-8" />
-              </div>
-              <div>
-                <p className="text-lg">여의도 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 영등포구 여의동로 330
-                </p>
-              </div>
+          {/* 순서 버전에서 아직 차례가 되지 않은 것들 */}
+          <button
+            disabled
+            className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 bg-button-hover disabled:cursor-not-allowed"
+          >
+            <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+              3
             </div>
-
-            {/* 순서 버전 */}
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                3
-              </div>
-              <div>
-                <p className="text-lg">반포 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 서초구 신반포로11길 40
-                </p>
-              </div>
+            <div className="flex flex-col items-start">
+              <p className="text-lg">여의도 한강공원</p>
+              <p className="text-sm text-text-2">
+                서울특별시 영등포구 여의동로 330
+              </p>
             </div>
-
-            {/* 순서x 버전 */}
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                <Logo className="text-white w-8 h-8" />
-              </div>
-              <div>
-                <p className="text-lg">망원 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 마포구 마포나루길 467
-                </p>
-              </div>
-            </div>
-
-            {/* 더미 카드들 */}
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                4
-              </div>
-              <div>
-                <p className="text-lg">잠원 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 서초구 잠원로 221
-                </p>
-              </div>
-            </div>
-
-            <div className="w-full rounded-xl border border-outline p-6 flex items-start gap-4">
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                <Logo className="text-white w-8 h-8" />
-              </div>
-              <div>
-                <p className="text-lg">이촌 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 용산구 이촌로72길 62
-                </p>
-              </div>
-            </div>
-          </div>
+          </button>
         </div>
-
-        {/* Right - 지도 (고정) */}
-        <div className="flex-1 rounded-lg border border-outline">지도 연결</div>
       </div>
     </div>
   );

--- a/src/components/dashboard/storyTrack/detail/TrackTabMenu.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackTabMenu.tsx
@@ -1,4 +1,4 @@
-type TabType = "overview" | "route" | "progress";
+type TabType = "route" | "map";
 
 interface Props {
   activeTab: TabType;
@@ -7,9 +7,8 @@ interface Props {
 
 export default function TrackTabMenu({ activeTab, onChange }: Props) {
   const tabs = [
-    { key: "overview", label: "개요" },
     { key: "route", label: "경로" },
-    { key: "progress", label: "진행 상황" },
+    { key: "map", label: "지도" },
   ] as const;
 
   return (

--- a/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
+++ b/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import Button from "@/components/common/Button";
-import { ListOrdered, MapPin, Play, TrendingUp, Users } from "lucide-react";
+import { ListOrdered, MapPin, Play, Shuffle, TrendingUp, Users } from "lucide-react";
 import { useRouter } from "next/navigation";
 
-export default function JoinedCard() {
+export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
   const router = useRouter();
+
+  // 추가: 진행률 계산
+  const total = track.totalSteps ?? 0;
+  const done = track.completedSteps ?? 0;
+  const percent = total > 0 ? Math.round((done / total) * 100) : 0;
+
   return (
     <>
       <div className="border border-outline rounded-xl">
@@ -16,37 +22,42 @@ export default function JoinedCard() {
           {/* 달성도 */}
           <div className="absolute top-3 right-3 flex items-center gap-1 px-3 py-2 rounded-lg text-white bg-primary-3 text-sm">
             <TrendingUp size={18} />
-            <span>40% 완료</span>
+            <span>{percent}% 완료</span>
           </div>
         </div>
         {/* Bottom */}
         <div className="p-6 space-y-4">
           {/* 제목과 소개 */}
           <div className="space-y-1">
-            <p>서울 한강 이야기</p>
+            <p>{track.title}</p>
             <p className="text-sm text-text-3 line-clamp-2 break-keep">
-              한강을 따라 펼쳐지는 추억의 여정. 여의도부터 뚝섬까지, 각 장소마다
-              숨겨진 이야기를 발견하세요.
+              {track.description}
             </p>
           </div>
 
           {/* 작성자 프로필 */}
           <div className="flex items-center gap-1.5">
             <div className="flex-none w-6 h-6 rounded-full bg-black text-white text-xs flex items-center justify-center">
-              {/* 그 사람의 프로필 */}홍
+              {/* 그 사람의 프로필 */}
+              {track.title?.[0] ?? "?"}
             </div>
-            <p className="text-xs text-text-2">홍길동</p>
+            <p className="text-xs text-text-2">참여</p>
           </div>
 
           {/* 진행 상황 */}
           <div className="space-y-2">
             <div className="flex justify-between items-center text-xs text-text-3">
               <span>진행 상황</span>
-              <span>2 / 5 완료</span>
+              <span>
+                {done} / {total} 완료
+              </span>
             </div>
             <div>
               <div className="relative w-full h-2 bg-button-hover rounded-full overflow-hidden">
-                <div className="absolute inset-0 w-[calc(100%/5*2)] bg-primary-2 rounded-full"></div>
+                <div
+                  className="absolute inset-0 bg-primary-2 rounded-full"
+                  style={{ width: `${percent}%` }}
+                ></div>
               </div>
             </div>
           </div>
@@ -54,24 +65,31 @@ export default function JoinedCard() {
           {/* 아이콘 요약 */}
           <div className="text-text-3 text-xs flex items-center gap-3">
             <div className="flex gap-1 items-center">
-              <ListOrdered size={16} />
-              순서대로
-              {/* <Shuffle size={18} />
-            <span>순서 무관</span> */}
+              {track.trackType === "FREE" ? (
+                <>
+                  <Shuffle size={18} />
+                  순서 무관
+                </>
+              ) : (
+                <>
+                  <ListOrdered size={16} />
+                  순서대로
+                </>
+              )}
             </div>
             <div className="flex gap-1 items-center">
               <MapPin size={16} />
-              5개 장소
+              {total}개 장소
             </div>
             <div className="flex gap-1 items-center">
               <Users size={16} />
-              123명
+              {track.totalMemberCount ?? 0}명
             </div>
           </div>
 
           {/* 버튼 */}
           <Button
-            onClick={() => router.push("/dashboard/storyTrack/1")}
+            onClick={() => router.push(`/dashboard/storyTrack/${track.storytrackId}`)}
             className="md:font-normal gap-1 w-full py-3"
           >
             <Play size={20} />

--- a/src/components/dashboard/storyTrack/joined/JoinedTrackPage.tsx
+++ b/src/components/dashboard/storyTrack/joined/JoinedTrackPage.tsx
@@ -1,8 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
 import StoryHeader from "../common/StoryHeader";
 import StoryMenuTab from "../common/StoryMenuTab";
 import JoinedCard from "./JoinedCard";
 
+import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
+
 export default function JoinedTrackPage() {
+  const [page, setPage] = useState(0);
+  const size = 10;
+
+  const { data: tracks, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["joinedStoryTrack", page, size],
+    queryFn: async ({ signal }) => {
+      return await storyTrackApi.joinedList({ page, size }, signal);
+    },
+  });
+
+  const pageInfo = tracks?.data;
+  const content: StoryTrackJoinedItem[] = (pageInfo?.content ?? []) as StoryTrackJoinedItem[];
+
   return (
     <>
       <div className="p-8 space-y-6">
@@ -12,11 +32,74 @@ export default function JoinedTrackPage() {
         {/* 메뉴 탭 */}
         <StoryMenuTab />
 
+        {/* 로딩 */}
+        {isLoading && (
+          <div className="rounded-xl border border-outline bg-white/80 p-6 text-text-2">
+            불러오는 중...
+          </div>
+        )}
+
+        {/* 에러 */}
+        {isError && (
+          <div className="rounded-xl border border-outline bg-white/80 p-6">
+            <p className="text-primary font-medium">불러오기에 실패했어요.</p>
+            <pre className="mt-3 text-xs whitespace-pre-wrap text-text-3">
+              {error instanceof Error ? error.message : String(error)}
+            </pre>
+            <button
+              className="mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
+              onClick={() => refetch()}
+              type="button"
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
         {/* List */}
-        <div className="grid grid-cols-3 gap-6">
-          {/* Card 1 */}
-          <JoinedCard />
-        </div>
+        {!isLoading && !isError && (
+          <>
+            <div className="grid grid-cols-3 gap-6">
+              {content.map((t) => (
+                <JoinedCard
+                  key={t.storytrackId}
+                  track={t}
+                />
+              ))}
+
+              {content.length === 0 && (
+                <div className="col-span-3 text-center text-text-3 py-12">
+                  참여한 트랙이 없어요.
+                </div>
+              )}
+            </div>
+
+            {/* 페이지네이션 */}
+            <div className="flex items-center justify-center gap-3 pt-4">
+              <button
+                className="px-3 py-2 rounded-xl border border-outline text-text-2 disabled:opacity-40"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                type="button"
+              >
+                이전
+              </button>
+
+              <span className="text-text-2">
+                {page + 1} / {pageInfo?.totalPages ?? 1}
+              </span>
+
+              <button
+                className="px-3 py-2 rounded-xl border border-outline text-text-2 disabled:opacity-40"
+                disabled={pageInfo?.last ?? true}
+                onClick={() => setPage((p) => p + 1)}
+                type="button"
+              >
+                다음
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </>
   );

--- a/src/components/dashboard/storyTrack/mine/MineCard.tsx
+++ b/src/components/dashboard/storyTrack/mine/MineCard.tsx
@@ -9,7 +9,7 @@ export default function MineCard() {
           {/* 이미지로 변경 */}
           <div className="w-full h-40 bg-amber-300 rounded-t-xl"></div>
           {/* 순서o or 순서x */}
-          <div className="absolute top-3 left-3 flex items-center gap-1 px-3 py-2 rounded-lg text-white bg-green-600 text-sm">
+          <div className="absolute top-3 right-3 flex items-center gap-1 px-3 py-2 rounded-lg text-white bg-admin text-sm">
             <ListOrdered size={18} />
             <span>순서대로</span>
             {/* <Shuffle size={18} />

--- a/src/components/dashboard/storyTrack/new/FirstForm.tsx
+++ b/src/components/dashboard/storyTrack/new/FirstForm.tsx
@@ -123,7 +123,7 @@ export default function FirstForm({ value, onChange }: Props) {
               alt="대표 이미지 미리보기"
               width={800}
               height={800}
-              className="max-w-full object-contain rounded-lg"
+              className="max-w-full max-h-full object-contain rounded-lg"
             />
           ) : (
             <div className="text-center space-y-2">

--- a/src/lib/api/dashboard/storyTrack.ts
+++ b/src/lib/api/dashboard/storyTrack.ts
@@ -57,4 +57,47 @@ export const storyTrackApi = {
       { signal }
     );
   },
+
+  /**
+   * 참여한 스토리트랙 목록 조회
+   * @param params 페이지네이션 파라미터
+   */
+  joinedList: (
+    params?: { page?: number; size?: number },
+    signal?: AbortSignal
+  ) => {
+    const page = params?.page ?? 0;
+    const size = params?.size ?? 10;
+
+    const sp = new URLSearchParams();
+    sp.set("page", String(page));
+    sp.set("size", String(size));
+
+    return apiFetchRaw<StoryTrackJoinedListResponse>(
+  `/api/v1/storytrack/participant/joinedList?${sp.toString()}`,
+  { signal }
+);
+  },
+
+  /**
+   * 내가 만든 스토리트랙 목록 조회
+   * @param params 페이지네이션 파라미터
+   */
+  mineList: (
+    params?: { page?: number; size?: number },
+    signal?: AbortSignal
+  ) => {
+    const page = params?.page ?? 0;
+    const size = params?.size ?? 10;
+
+    const sp = new URLSearchParams();
+    sp.set("page", String(page));
+    sp.set("size", String(size));
+
+    return apiFetchRaw<StoryTrackMineListResponse>(
+  `/api/v1/storytrack/creater/storytrackList?${sp.toString()}`,
+  { signal }
+);
+
+  },
 };

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -26,8 +26,9 @@ type StoryTrackItem = {
   isPublic: number;
   price: number;
   totalSteps: number;
-  totalParticipant: number;
   createdAt: string;
+  totalMemberCount: number;
+  memberType: string;
 };
 
 type StoryTrackListPage = {
@@ -63,13 +64,11 @@ type CreateStorytrackResponse = {
   capsuleList: number[]; // capsuleId 배열
 };
 
-
 type ApiEnvelope<T> = {
   code: string;
   message: string;
   data: T;
 };
-
 
 type PageEnvelope<T> = {
   content: T[];
@@ -175,10 +174,12 @@ type StoryTrackMineListPage = {
   last: boolean;
 };
 
-
-
 // 응답 타입
-type PublicStoryTrackListResponse = ApiEnvelope<PageEnvelope<PublicStoryTrackItem>>;
-type JoinedStoryTrackListResponse = ApiEnvelope<PageEnvelope<JoinedStoryTrackItem>>;
+type PublicStoryTrackListResponse = ApiEnvelope<
+  PageEnvelope<PublicStoryTrackItem>
+>;
+type JoinedStoryTrackListResponse = ApiEnvelope<
+  PageEnvelope<JoinedStoryTrackItem>
+>;
 type MineStoryTrackListResponse = ApiEnvelope<PageEnvelope<MineStoryTrackItem>>;
 type StoryTrackMineListResponse = ApiResponse<StoryTrackMineListPage>;

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -60,3 +60,123 @@ type CreateStorytrackResponse = {
   totalSteps: number;
   capsuleList: number[]; // capsuleId 배열
 };
+
+
+type ApiEnvelope<T> = {
+  code: string;
+  message: string;
+  data: T;
+};
+
+
+type PageEnvelope<T> = {
+  content: T[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalElements: number;
+  last: boolean;
+};
+
+/** 공개 전체 스토리트랙   */
+type PublicStoryTrackItem = {
+  storytrackId: number;
+  title: string;
+  description: string;
+  trackType: string;
+  isPublic: number;
+  price: number;
+  totalSteps: number;
+  createdAt: string;
+  totalMemberCount: number;
+};
+
+/**  참여한 스토리트랙  */
+type JoinedStoryTrackItem = {
+  memberId: number;
+  storytrackId: number;
+  title: string;
+  description: string;
+  trackType: string;
+  isPublic: number;
+  price: number;
+  totalSteps: number;
+  completedSteps: number;
+  lastCompletedStep: number;
+  startedAt: string;
+  completedAt: string;
+  createdAt: string;
+  totalMemberCount: number;
+};
+
+/**  내가 만든 스토리트랙  */
+type MineStoryTrackItem = {
+  storytrackId: number;
+  title: string;
+  description: string;
+  trackType: string;
+  isPublic: number;
+  price: number;
+  totalSteps: number;
+  createdAt: string;
+  totalMemberCount: number;
+};
+
+/* 참여한 스토리트랙 리스트 item (participant/joinedList) */
+type StoryTrackJoinedItem = {
+  memberId: number;
+  storytrackId: number;
+  title: string;
+  description: string;
+  trackType: string;
+  isPublic: number;
+  price: number;
+  totalSteps: number;
+  completedSteps: number;
+  lastCompletedStep: number;
+  startedAt: string;
+  completedAt: string;
+  createdAt: string;
+  totalMemberCount: number;
+};
+
+type StoryTrackJoinedListPage = {
+  content: StoryTrackJoinedItem[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalElements: number;
+  last: boolean;
+};
+
+type StoryTrackJoinedListResponse = ApiResponse<StoryTrackJoinedListPage>;
+
+/* 내가 만든 스토리트랙 리스트 item (creater/storytrackList) */
+type StoryTrackMineItem = {
+  storytrackId: number;
+  title: string;
+  description: string;
+  trackType: string;
+  isPublic: number;
+  price: number;
+  totalSteps: number;
+  createdAt: string;
+  totalMemberCount: number;
+};
+
+type StoryTrackMineListPage = {
+  content: StoryTrackMineItem[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalElements: number;
+  last: boolean;
+};
+
+
+
+// 응답 타입
+type PublicStoryTrackListResponse = ApiEnvelope<PageEnvelope<PublicStoryTrackItem>>;
+type JoinedStoryTrackListResponse = ApiEnvelope<PageEnvelope<JoinedStoryTrackItem>>;
+type MineStoryTrackListResponse = ApiEnvelope<PageEnvelope<MineStoryTrackItem>>;
+type StoryTrackMineListResponse = ApiResponse<StoryTrackMineListPage>;


### PR DESCRIPTION
## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->

## ✅ 관련 이슈

<!-- Close #89  -->
<!-- 없으면
_N/A_
-->

- Close #89 

## 🛠️ 상세 작업 내용

• 스토리트랙 조회 기능 구현
공개 스토리트랙(all) / 참여한 스토리트랙(joined) / 내가 만든 스토리트랙(mine) API 연결
React Query 기반으로 목록 조회, 로딩/에러/빈 상태 처리
스토리트랙 카드 UI에 실제 API 데이터 바인딩
참여 트랙 카드에서 진행률(완료 개수/전체 개수) 계산 및 표시
스토리트랙 ID 기반으로 상세 페이지 이동 연결
storyTrackApi에 조회 관련 API 추가


