### PR TITLE
[#94] fix(public): 공개 편지 조회 시 위치를 가져오기 이전에 useQuery가 실행되어 위치 좌표가 0,0으로 전송되는…

### DIFF
--- a/src/components/dashboard/map/MapContents.tsx
+++ b/src/components/dashboard/map/MapContents.tsx
@@ -149,7 +149,11 @@ export default function MapContents() {
   const filteredData = filter(data);
 
   return id ? (
-    <LetterDetailView isPublic={true} capsuleId={Number(id)} />
+    <LetterDetailView
+      isPublic={true}
+      capsuleId={Number(id)}
+      initialLocation={myLocation}
+    />
   ) : (
     <div className="h-full flex flex-col gap-4">
       {/* 헤더 */}


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
공개편지 조회 시 `locationLat`과 `locationLng`가 0으로 전송되는 문제를 해결했습니다. `MapContents`에서 이미 가져온 위치 정보를 `LetterDetailView`에 전달하여, 위치 정보가 준비된 상태에서 API 호출이 이루어지도록 수정했습니다.
## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #94 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] `LetterDetailView`에 `initialLocation` prop 추가
  - `MapContents`에서 전달받은 위치 정보를 우선 사용
  - `initialLocation`이 없을 때만 `getCurrentPosition()`으로 위치 정보 가져오기
- [x] `MapContents`에서 `LetterDetailView` 호출 시 `myLocation` 전달
  - 이미 가져온 위치 정보를 `initialLocation` prop으로 전달
- [x] `useQuery`의 `enabled` 조건 수정 **(핵심)**
  - 위치 정보가 준비될 때까지 API 호출 대기
  - `initialLocation`이 있으면 즉시 실행, 없으면 `currentLocation`이 설정될 때까지 대기

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="799" height="182" alt="image" src="https://github.com/user-attachments/assets/c8793581-c145-47e9-a2ba-cae6dbcc216e" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

  **바꾼 코드 핵심 요약**
  위치 정보를 가져오기 전에 useQuery가 실행됐던게 문제,
 initialLocation이 있으면 즉시 실행, 없으면 currentLocation이 설정될 때까지 대기
 