### PR TITLE
[#97] feat(backup): 수신한 편지 단일 백업 기능 구현

### DIFF
--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -37,6 +37,7 @@ import { adminCapsulesApi } from "@/lib/api/admin/capsules/adminCapsules";
 import { authApiClient } from "@/lib/api/auth/auth.client";
 import { guestCapsuleApi } from "@/lib/api/capsule/guestCapsule";
 import {
+  backupCapsule,
   deleteCapsuleAsReceiver,
   deleteCapsuleAsSender,
   getCapsuleLikeCount,
@@ -141,6 +142,9 @@ export default function LetterDetailModal({
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [isDeleteSuccessOpen, setIsDeleteSuccessOpen] = useState(false);
 
+  // 백업
+  const [isBackupSuccessOpen, setIsBackupSuccessOpen] = useState(false);
+
   // 좋아요
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
@@ -235,6 +239,29 @@ export default function LetterDetailModal({
           : typeof err === "string"
           ? err
           : "삭제 중 오류가 발생했습니다.";
+      alert(msg);
+    },
+  });
+
+  //백업 mutation
+  const backupMutation = useMutation({
+    mutationKey: ["capsuleBackup", capsuleId],
+    mutationFn: backupCapsule,
+    onSuccess: (res) => {
+      const url = res.data.authUrl;
+      if (res.data.status === "NEED_CONNECT") {
+        window.open(url, "_blank");
+        return;
+      }
+      setIsBackupSuccessOpen(true);
+    },
+    onError: (err) => {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : typeof err === "string"
+          ? err
+          : "백업 중 오류가 발생했습니다.";
       alert(msg);
     },
   });
@@ -598,6 +625,15 @@ export default function LetterDetailModal({
         />
       )}
 
+      {backupMutation.isPending && (
+        <div className="fixed inset-0 z-1000 bg-black/40 flex items-center justify-center">
+          <div className="bg-white rounded-xl px-6 py-4 flex items-center gap-3">
+            <span className="animate-spin rounded-full h-5 w-5 border-2 border-primary-2 border-t-transparent" />
+            <span className="text-sm font-medium">백업 중...</span>
+          </div>
+        </div>
+      )}
+
       {/* 북마크 성공 모달 */}
       {bookmarkToast.open && (
         <ActiveModal
@@ -649,6 +685,23 @@ export default function LetterDetailModal({
         />
       )}
 
+      {/* 백업 성공 모달 */}
+      {isBackupSuccessOpen && (
+        <ActiveModal
+          active="success"
+          title="백업 완료"
+          content="구글 드라이브에 캡슐 내용이 저장되었습니다."
+          open={isBackupSuccessOpen}
+          onClose={() => setIsBackupSuccessOpen(false)}
+          onConfirm={() => {
+            setIsBackupSuccessOpen(false);
+            if (closeHref) router.push(closeHref);
+            else router.back();
+            router.refresh();
+          }}
+        />
+      )}
+
       <div className="flex h-full justify-center md:p-15 p-6">
         <div className="flex flex-col max-w-300 w-full h-[calc(100vh-48px)] md:h-[calc(100vh-120px)] bg-white rounded-2xl">
           {/* Header */}
@@ -689,6 +742,16 @@ export default function LetterDetailModal({
                       <DropdownMenuLabel>관리</DropdownMenuLabel>
                       <DropdownMenuSeparator />
                       <DropdownMenuGroup>
+                        {isReceiver && (
+                          <DropdownMenuItem
+                            onClick={() => backupMutation.mutate(capsuleId)}
+                          >
+                            <PencilLine className="text-primary" />
+                            {backupMutation.isPending
+                              ? "백업 중..."
+                              : "백업하기"}
+                          </DropdownMenuItem>
+                        )}
                         {isSender && (
                           <DropdownMenuItem
                             onClick={() => {

--- a/src/components/dashboard/contents/mailbox/EnvelopeCard.tsx
+++ b/src/components/dashboard/contents/mailbox/EnvelopeCard.tsx
@@ -253,7 +253,7 @@ export default function EnvelopeCard({
             </div>
 
             <div className="absolute top-1/2 left-1/2 -translate-1/2 w-30">
-              <p className="text-center text-sm line-clamp-3">
+              <p className="text-center text-sm line-clamp-3 break-keep">
                 {capsule.title}
               </p>
             </div>

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -402,3 +402,19 @@ export async function readSendCapsule(
     }
   );
 }
+
+/**
+ * 구글 드라이브 백업 API 호출
+ * 사용자가 수신한 캡슐을 구글 드라이브에 CSV 파일로 백업합니다.
+ * @param capsuleId 캡슐 ID
+ */
+export async function backupCapsule(
+  capsuleId: number
+): Promise<ApiResponse<CapsuleBackupResponse>> {
+  return apiFetchRaw<ApiResponse<CapsuleBackupResponse>>(
+    `/api/v1/backup/google-drive/${capsuleId}`,
+    {
+      method: "POST",
+    }
+  );
+}

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -125,3 +125,9 @@ interface CapsuleSendReadResponse {
   locationLng: number;
   result: string;
 }
+
+interface CapsuleBackupResponse {
+  status: string;
+  description: string;
+  authUrl: string;
+}


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
수신한 편지 단일 백업 기능 구현

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #97 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 수신한 편지 단일 백업 기능 구현
- [x] 편지 Card title 단어 잘리는 거 방지

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- 구글 드라이브 재연동 시 이슈 발생
  상황: 이미 구글 연동이 된 계정에서 사용자 흐름을 체크하기 위해 구글 연동을 끊음. 그리고 다시 연동하여 백업하기 위해 API 호출하였으나 500 Internal Server Error가 나옴
  Request URL: http://localhost:8080/api/v1/backup/google-drive/9
  Responese: {code: "BA001", message: "구글 드라이브 업로드 중 에러가 발생했습니다.", data: null}

백업이 되는 것은 확인하였으나, 이슈 발생 이후 처음 구글 연동하는 경우의 사용자 흐름을 체크하지 못해 조금 더 수정이 필요할 것 같습니다. 
