### PR TITLE
[#91] fix(capsule): 공개 캡슐, URL+비밀번호 캡슐 조회 시 중복 요청으로 인해 조회가 실패하는 현상 수정

### DIFF
--- a/src/components/capsule/detail/LetterDetailView.tsx
+++ b/src/components/capsule/detail/LetterDetailView.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import LetterDetailModal from "./LetterDetailModal";
+import LetterDetailModal, { type UICapsule } from "./LetterDetailModal";
 import LetterLockedView from "./LetterLockedView";
 import { guestCapsuleApi } from "@/lib/api/capsule/guestCapsule";
 
@@ -120,7 +120,8 @@ export default function LetterDetailView({
     retry: false,
     // 공개 캡슐의 경우 위치 정보가 준비될 때까지 대기
     // initialLocation이 있으면 즉시 실행, 없으면 currentLocation이 설정될 때까지 대기
-    enabled: capsuleId > 0 && (initialLocation !== null || currentLocation !== null),
+    enabled:
+      capsuleId > 0 && (initialLocation !== null || currentLocation !== null),
   });
 
   if (isLoading) {
@@ -167,6 +168,22 @@ export default function LetterDetailView({
   }
 
   // 열람 가능
+  // LetterDetailView에서 이미 데이터를 가져왔으므로, LetterDetailModal에 전달하여 중복 요청 방지
+  const modalData: UICapsule = {
+    capsuleColor: capsule.capsuleColor ?? null,
+    title: capsule.title,
+    content: capsule.content,
+    createdAt: capsule.createdAt,
+    writerNickname: capsule.senderNickname,
+    recipient: capsule.recipient ?? null,
+    unlockType: capsule.unlockType,
+    unlockAt: capsule.unlockAt,
+    unlockUntil: capsule.unlockUntil,
+    locationName: capsule.locationName ?? null,
+    viewStatus: !!capsule.viewStatus,
+    isBookmarked: !!capsule.isBookmarked,
+  };
+
   return (
     <div className="min-h-screen w-full flex items-center justify-center p-8">
       <LetterDetailModal
@@ -175,6 +192,7 @@ export default function LetterDetailView({
         role="USER"
         open={true}
         password={password}
+        initialData={modalData}
       />
     </div>
   );

--- a/src/lib/api/capsule/attachment.ts
+++ b/src/lib/api/capsule/attachment.ts
@@ -1,0 +1,126 @@
+import { apiFetchRaw } from "../fetchClient";
+
+/**
+ * 파일 업로드 응답 DTO
+ */
+export type CapsuleAttachmentUploadResponse = {
+  attachmentId: number;
+  s3Key: string | null;
+  presignedUrl: string | null;
+  expireAt: string | null; // ISO 8601 형식
+};
+
+/**
+ * Presigned URL 업로드 요청 DTO
+ */
+export type CapsuleAttachmentUploadRequest = {
+  filename: string;
+  mimeType: string;
+  size: number;
+};
+
+/**
+ * 파일 업로드 API
+ */
+export const attachmentApi = {
+  /**
+   * 서버 업로드 방식
+   * - 파일을 multipart/form-data로 서버에 전송
+   * - 서버가 S3에 업로드하고 DB에 저장
+   * - 응답: attachmentId만 반환 (나머지는 null)
+   */
+  uploadByServer: async (
+    file: File,
+    signal?: AbortSignal
+  ): Promise<CapsuleAttachmentUploadResponse> => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const response = await apiFetchRaw<{
+      code: string;
+      message: string;
+      data: CapsuleAttachmentUploadResponse;
+    }>("/api/v1/capsule/upload", {
+      method: "POST",
+      body: formData,
+      signal,
+      // FormData를 사용할 때는 Content-Type 헤더를 설정하지 않음 (브라우저가 자동으로 boundary 설정)
+      headers: {},
+    });
+
+    return response.data;
+  },
+
+  /**
+   * Presigned URL 업로드 방식
+   * - 1단계: 메타데이터만 서버에 전송하여 presignedUrl 받기
+   * - 2단계: 받은 presignedUrl로 S3에 직접 업로드
+   * - 응답: attachmentId + s3Key + presignedUrl + expireAt
+   */
+  uploadByPresignedUrl: async (
+    file: File,
+    signal?: AbortSignal
+  ): Promise<CapsuleAttachmentUploadResponse> => {
+    // 1단계: Presigned URL 요청
+    const request: CapsuleAttachmentUploadRequest = {
+      filename: file.name,
+      mimeType: file.type,
+      size: file.size,
+    };
+
+    const response = await apiFetchRaw<{
+      code: string;
+      message: string;
+      data: CapsuleAttachmentUploadResponse;
+    }>("/api/v1/capsule/upload/presign", {
+      method: "POST",
+      json: request,
+      signal,
+    });
+
+    const { attachmentId, presignedUrl, s3Key } = response.data;
+
+    if (!presignedUrl) {
+      throw new Error("Presigned URL을 받지 못했습니다.");
+    }
+
+    // 2단계: S3에 직접 업로드
+    const uploadResponse = await fetch(presignedUrl, {
+      method: "PUT",
+      body: file,
+      headers: {
+        "Content-Type": file.type,
+      },
+      signal,
+    });
+
+    if (!uploadResponse.ok) {
+      throw new Error("S3 업로드에 실패했습니다.");
+    }
+
+    return {
+      attachmentId,
+      s3Key: s3Key ?? null,
+      presignedUrl: null, // 업로드 완료 후에는 null로 설정
+      expireAt: response.data.expireAt,
+    };
+  },
+
+  /**
+   * 임시 파일 삭제
+   */
+  deleteTemp: async (
+    attachmentId: number,
+    signal?: AbortSignal
+  ): Promise<void> => {
+    await apiFetchRaw<{
+      code: string;
+      message: string;
+      data: Record<string, never>;
+    }>(`/api/v1/capsule/upload/${attachmentId}`, {
+      method: "DELETE",
+      signal,
+    });
+  },
+};
+


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

캡슐 조회 시 발생하는 두 가지 중복 요청 문제를 해결했습니다:

1. **공개 캡슐 조회 시 중복 요청**: `LetterDetailView`와 `LetterDetailModal`에서 각각 `read` API를 호출하여 중복 요청 발생
2. **URL+비밀번호 캡슐 조회 시 중복 요청**: `LetterPasswordModal`과 `LetterDetailView`에서 각각 `read` API를 호출하여 중복 요청 발생

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #91 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

### 버그 수정 1: 공개 캡슐 조회 시 중복 요청 문제

- [x] `LetterDetailView`에서 가져온 데이터를 `LetterDetailModal`에 `initialData` prop으로 전달
  - `result === "SUCCESS"`일 때 `UICapsule` 형태로 데이터 변환하여 전달
- [x] `LetterDetailModal`에 `initialData` prop 추가
  - `initialData`가 있으면 `useQuery`의 `enabled`를 `false`로 설정하여 API 호출 방지
  - `initialData`가 있으면 해당 데이터를 우선 사용, 없으면 기존처럼 `useQuery` 결과 사용

**해결 전:**

```
LetterDetailView → guestCapsuleApi.read() [1차 요청]
  └─> LetterDetailModal → guestCapsuleApi.read() [2차 요청 - 중복!]
```

**해결 후:**

```
LetterDetailView → guestCapsuleApi.read() [1차 요청만]
  └─> LetterDetailModal (initialData 전달받음) → useQuery 비활성화
```

### 버그 수정 2: URL+비밀번호 캡슐 조회 시 중복 요청 문제

- [x] `LetterPasswordModal`에서 `read` API 호출 제거
  - 비밀번호 입력만 받고 `onSuccess(password)`로 전달
  - 실제 `read` API 호출은 `LetterDetailView`에서만 수행하도록 변경
  - 중복 요청 방지를 위해 불필요한 위치 정보 수집 로직 제거

**해결 전:**

```
LetterPasswordModal → guestCapsuleApi.read() [1차 요청]
  └─> LetterDetailView → guestCapsuleApi.read() [2차 요청 - 중복!]
```

**해결 후:**

```
LetterPasswordModal (비밀번호만 전달)
  └─> LetterDetailView → guestCapsuleApi.read() [1차 요청만]
```

### 타입 정의

- [x] `UICapsule` 타입을 `LetterDetailModal`에서 export
- [x] `UnlockType` 타입 정의 추가

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

_N/A_

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

### 공개 캡슐 중복 요청 방지

- `LetterDetailModal`의 `initialData` prop은 optional이므로, 다른 경로에서 `LetterDetailModal`을 사용할 때는 기존처럼 자체적으로 API를 호출합니다.
- `LetterDetailView`에서 `result === "SUCCESS"`일 때만 `initialData`를 전달하므로, 조건 미충족(`result === "FAIL"`)인 경우에는 기존처럼 `LetterLockedView`를 표시합니다.

### URL+비밀번호 캡슐 중복 요청 방지

- `LetterPasswordModal`에서 `read` API 호출을 제거했으므로, 비밀번호 검증은 `LetterDetailView`에서 `read` API 호출 시 백엔드에서 처리됩니다.
- `LetterPasswordModal`에서 에러 처리 로직이 제거되었으므로, 비밀번호 오류는 `LetterDetailView`에서 처리됩니다.
- `LetterPasswordModal`은 이제 비밀번호 입력 UI만 담당하며, 실제 검증과 조회는 `LetterDetailView`에서 수행합니다.

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

공개편지, URL +비밀번호 편지가 잘 봐지는지 확인 부탁드립니다~
