### PR TITLE
[#72] feat(like): 수정된 좋아요 DTO에 맞춰서 좋아요 기능 수정 및 모달 연결

### DIFF
--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -284,10 +284,14 @@ export default function LetterDetailModal({
     },
   });
 
-  // 좋아요 수 초기화
+  // 좋아요 수 및 상태 초기화
   useEffect(() => {
     if (likeData) {
-      setLikeCount(likeData.likeCount);
+      setLikeCount(likeData.capsuleLikeCount);
+      // isLiked가 있으면 초기 상태 설정 (readLike API 응답에 포함됨)
+      if (typeof likeData.isLiked === "boolean") {
+        setIsLiked(likeData.isLiked);
+      }
     }
   }, [likeData]);
 
@@ -309,7 +313,7 @@ export default function LetterDetailModal({
       return { previousIsLiked, previousLikeCount, nextIsLiked };
     },
     onSuccess: (data, _variables, context) => {
-      if (data.data) setLikeCount(data.data.likeCount);
+      if (data.data) setLikeCount(data.data.capsuleLikeCount);
       if (context) setIsLiked(context.nextIsLiked);
     },
     onError: (err, _variables, context) => {
@@ -721,7 +725,7 @@ export default function LetterDetailModal({
           }}
         />
       )}
-      
+
       {/* 신고 모달 */}
       {isReportOpen && (
         <ReportModal

--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -156,6 +156,10 @@ export default function LetterDetailModal({
   // 좋아요
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
+  const [likeToast, setLikeToast] = useState<{
+    open: boolean;
+    mode: "ADD" | "REMOVE";
+  }>({ open: false, mode: "ADD" });
 
   // 북마크
   const [isBookmarked, setIsBookmarked] = useState(false);
@@ -314,7 +318,14 @@ export default function LetterDetailModal({
     },
     onSuccess: (data, _variables, context) => {
       if (data.data) setLikeCount(data.data.capsuleLikeCount);
-      if (context) setIsLiked(context.nextIsLiked);
+      if (context) {
+        setIsLiked(context.nextIsLiked);
+        // 좋아요 성공 모달 표시
+        setLikeToast({
+          open: true,
+          mode: context.nextIsLiked ? "ADD" : "REMOVE",
+        });
+      }
     },
     onError: (err, _variables, context) => {
       const errorCode =
@@ -670,6 +681,21 @@ export default function LetterDetailModal({
           }
           open={bookmarkToast.open}
           onClose={() => setBookmarkToast((prev) => ({ ...prev, open: false }))}
+        />
+      )}
+
+      {/* 좋아요 성공 모달 */}
+      {likeToast.open && (
+        <ActiveModal
+          active="success"
+          title={likeToast.mode === "ADD" ? "좋아요 완료" : "좋아요 취소"}
+          content={
+            likeToast.mode === "ADD"
+              ? "좋아요가 완료되었습니다."
+              : "좋아요가 취소되었습니다."
+          }
+          open={likeToast.open}
+          onClose={() => setLikeToast((prev) => ({ ...prev, open: false }))}
         />
       )}
 

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -103,8 +103,9 @@ interface CapsuleLikeRequest {
 }
 
 interface CapsuleLikeResponse {
-  likeCount: number;
+  capsuleLikeCount: number;
   message: string;
+  isLiked?: boolean; // readLike API 응답에만 포함됨
 }
 
 interface CapsuleSendReadResponse {


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

공개 캡슐에 좋아요 기능을 구현했습니다. 사용자는 공개 캡슐에 좋아요를 누르거나 취소할 수 있으며, 좋아요 수를 확인할 수 있습니다. 좋아요 성공/취소 시 모달이 표시됩니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #72 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] `CapsuleLikeResponse` 타입에 `isLiked` 필드 추가 (`createCapsule.d.ts`)
- [x] `LetterDetailModal`에 좋아요 기능 통합
  - [x] `readLike` API를 통한 초기 좋아요 상태 설정 (`isLiked` 필드 활용)
  - [x] 낙관적 업데이트를 사용한 좋아요 토글 mutation 구현
  - [x] 에러 처리 로직 구현 (CPS016: 중복 좋아요, CPS018: 좋아요 해제 실패)
  - [x] 좋아요 성공/취소 모달 추가 (북마크 모달과 동일한 패턴)

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

_N/A_
<img width="1363" height="141" alt="image" src="https://github.com/user-attachments/assets/a0dee3a3-583c-4e9d-bb77-1e4367aba973" />
<img width="583" height="229" alt="image" src="https://github.com/user-attachments/assets/fa7c45ed-b5c9-4ff1-b647-7dc6e559dabc" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

- 좋아요 기능은 **공개 캡슐(`isPublic === true`)**에서만 동작합니다.
- 비공개 캡슐이나 보낸/받은 편지에서는 좋아요 버튼이 표시되지 않습니다.
- 좋아요 상태는 `readLike` API 응답의 `isLiked` 필드를 통해 초기화됩니다.
- 낙관적 업데이트를 사용하여 즉시 UI가 업데이트되며, API 응답 후 실제 좋아요 수로 동기화됩니다.
- 좋아요 성공 모달은 `ActiveModal` 컴포넌트를 사용합니다.

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- 낙관적 업데이트가 올바르게 구현되었는지
- 좋아요 모달이 정상적으로 나타나는지
- 좋아요 이후, 캡슐 재입장 하여도 정상적으로 표시되는지

