### PR TITLE
feat(storytrack): 스토리트랙 세부 조회 기능 구현

### DIFF
--- a/src/components/dashboard/contents/mailbox/EnvelopeCard.tsx
+++ b/src/components/dashboard/contents/mailbox/EnvelopeCard.tsx
@@ -7,6 +7,7 @@ import Logo from "@/components/common/Logo";
 import { Clock, Lock, MapPin, Unlock, Pencil, PencilOff } from "lucide-react";
 import { CAPTURE_COLOR_MAP } from "@/constants/capsulePalette";
 import { useRouter } from "next/navigation";
+import { distanceMeters } from "@/lib/hooks/distanceMeters";
 
 type LatLng = { lat: number; lng: number };
 
@@ -15,25 +16,6 @@ type Props = {
   type: "send" | "receive" | "bookmark";
   currentPos?: LatLng | null;
 };
-
-/* 위치 계산 */
-function distanceMeters(a: LatLng, b: LatLng) {
-  const R = 6371e3;
-  const toRad = (v: number) => (v * Math.PI) / 180;
-
-  const dLat = toRad(b.lat - a.lat);
-  const dLng = toRad(b.lng - a.lng);
-
-  const lat1 = toRad(a.lat);
-  const lat2 = toRad(b.lat);
-
-  const x =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
-
-  const c = 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
-  return R * c;
-}
 
 /* 타입 별 UI */
 function getEnvelopeStatus(

--- a/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import BackButton from "@/components/common/BackButton";
 import TrackHeader from "./TrackHeader";
 import TrackOverview from "./TrackOverview";
@@ -8,16 +8,118 @@ import TrackProgress from "./TrackProgress";
 import TrackTabMenu from "./TrackTabMenu";
 import TrackRoute from "./TrackRoute";
 import TrackMap from "./TrackMap";
+import { useQuery } from "@tanstack/react-query";
+import { useParams, useSearchParams } from "next/navigation";
+import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
+import LetterDetailView from "@/components/capsule/detail/LetterDetailView";
+import ActiveModal from "@/components/common/ActiveModal";
 
 type TabType = "route" | "map";
 
 export default function TrackDetailPage() {
+  const [isLocationFailOpen, setIsLocationFailOpen] = useState(false);
   const [tab, setTab] = useState<TabType>("map");
+  //스토리트랙 id
+  const params = useParams();
+  const storytrackId =
+    typeof params.trackId === "string" ? params.trackId : undefined;
 
+  //캡슐 페이지네이션
+  const [page] = useState(0);
+  const [size] = useState(100);
+
+  //캡슐 상세 조회 시 캡슐 id
+  const searchParams = useSearchParams();
+  const capsuleId = searchParams.get("id");
+
+  // 스토리트랙 상세 조회
+  const { data, isError, error } = useQuery({
+    queryKey: ["storyTrackDetail", storytrackId],
+    queryFn: async ({ signal }) => {
+      return await storyTrackApi.storyTrackDetail(
+        { storytrackId, page, size },
+        signal
+      );
+    },
+    enabled: !!storytrackId,
+  });
+
+  //사용자 위치
+  const [myLocation, setMyLocation] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(null);
+
+  //위치 정보 에러 메세지
+  const [locationError, setLocationError] = useState<string | null>(null);
+
+  //위치 정보 가져오기 실패했을 때 상황에 따른 에러 메세지
+  const showErrorMsg = (error: GeolocationPositionError) => {
+    switch (error.code) {
+      case error.PERMISSION_DENIED:
+        setLocationError("Geolocation API의 사용 요청을 거부했습니다.");
+        break;
+      case error.POSITION_UNAVAILABLE:
+        setLocationError("위치 정보를 사용할 수 없습니다.");
+        break;
+      case error.TIMEOUT:
+        setLocationError(
+          "위치 정보를 가져오기 위한 요청이 허용 시간을 초과했을습니다."
+        );
+        break;
+      default:
+        setLocationError(
+          "알 수 없는 오류가 발생했습니다. 관리자에게 문의하세요."
+        );
+        break;
+    }
+    setIsLocationFailOpen(true);
+  };
+
+  useEffect(() => {
+    if ("geolocation" in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          setMyLocation({
+            lat: position.coords.latitude, //위도값 저장
+            lng: position.coords.longitude, //경도값 저장
+          });
+        },
+        (err) => {
+          showErrorMsg(err);
+        }
+      );
+    }
+  }, []);
+
+  if (isError) {
+    console.error(error);
+    return <div>{String(error)}</div>;
+  }
   return (
     // 모바일: 전체 스크롤
     // 데스크탑: 내부 패널 스크롤
     <div className="min-h-dvh lg:h-screen flex flex-col p-4 lg:p-8 gap-4 lg:gap-8">
+      {capsuleId &&
+        (myLocation ? (
+          <LetterDetailView
+            isPublic={true}
+            capsuleId={Number(capsuleId)}
+            initialLocation={myLocation}
+          />
+        ) : (
+          <ActiveModal
+            active="fail"
+            title="위치 정보 접근 차단"
+            content={`${locationError}`}
+            open={isLocationFailOpen}
+            onClose={() => setIsLocationFailOpen(false)}
+            onConfirm={() => {
+              setIsLocationFailOpen(false);
+              window.location.reload();
+            }}
+          />
+        ))}
       <div className="flex-none">
         <BackButton />
       </div>
@@ -38,17 +140,32 @@ export default function TrackDetailPage() {
         {/* Right */}
         <div className="lg:flex-3 flex flex-col gap-4 lg:gap-6 min-h-0">
           {/* Top */}
-          <div className="border border-outline rounded-2xl overflow-hidden">
-            <TrackProgress />
-          </div>
+          {/* role이 참여자일 경우에만 보이도록 처리할 예정 */}
+          {data?.data.memberType === "NOT_JOINED" ? (
+            <div className="border border-outline rounded-2xl overflow-hidden">
+              <TrackProgress />
+            </div>
+          ) : (
+            ""
+          )}
 
           {/* Bottom */}
           <div className="border border-outline rounded-2xl overflow-hidden flex flex-col lg:flex-1 lg:min-h-0">
             <TrackTabMenu activeTab={tab} onChange={setTab} />
 
             <div className="p-4 lg:p-6 overflow-visible lg:overflow-auto lg:flex-1 lg:min-h-0">
-              {tab === "map" && <TrackMap />}
-              {tab === "route" && <TrackRoute />}
+              {tab === "map" && (
+                <TrackMap
+                  storytrackType={data?.data.storytrackType}
+                  capsuleList={data?.data.paths.content}
+                />
+              )}
+              {tab === "route" && (
+                <TrackRoute
+                  storytrackType={data?.data.storytrackType}
+                  capsuleList={data?.data.paths.content}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
@@ -141,12 +141,11 @@ export default function TrackDetailPage() {
         <div className="lg:flex-3 flex flex-col gap-4 lg:gap-6 min-h-0">
           {/* Top */}
           {/* role이 참여자일 경우에만 보이도록 처리할 예정 */}
-          {data?.data.memberType === "NOT_JOINED" ? (
+          {(data?.data.memberType === "PARTICIPANT" ||
+            data?.data.memberType === "COMPLETED") && (
             <div className="border border-outline rounded-2xl overflow-hidden">
               <TrackProgress />
             </div>
-          ) : (
-            ""
           )}
 
           {/* Bottom */}
@@ -162,8 +161,10 @@ export default function TrackDetailPage() {
               )}
               {tab === "route" && (
                 <TrackRoute
+                  memberType={data?.data.memberType}
                   storytrackType={data?.data.storytrackType}
                   capsuleList={data?.data.paths.content}
+                  completedCapsuleList={data?.data.completedCapsuleId}
                 />
               )}
             </div>

--- a/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
@@ -161,6 +161,7 @@ export default function TrackDetailPage() {
               )}
               {tab === "route" && (
                 <TrackRoute
+                  myLocation={myLocation}
                   memberType={data?.data.memberType}
                   storytrackType={data?.data.storytrackType}
                   capsuleList={data?.data.paths.content}

--- a/src/components/dashboard/storyTrack/detail/TrackMap.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackMap.tsx
@@ -1,9 +1,98 @@
-export default function TrackMap() {
+import { useRef } from "react";
+import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
+
+type TrackMapProps = {
+  storytrackType?: "SEQUENTIAL" | "PARALLEL";
+  capsuleList?: StoryTrackPathItem[];
+};
+
+export default function TrackMap({
+  storytrackType,
+  capsuleList,
+}: TrackMapProps) {
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+
+  // 지도 중심 좌표 계산 (초기 렌더링용)
+  const mapCenter = () => {
+    if (capsuleList && capsuleList?.length > 0) {
+      const avgLat =
+        capsuleList.reduce(
+          (sum, item) => sum + item.capsule.unlock.location.locationLat,
+          0
+        ) / capsuleList.length;
+      const avgLng =
+        capsuleList.reduce(
+          (sum, item) => sum + item.capsule.unlock.location.locationLng,
+          0
+        ) / capsuleList.length;
+      return { lat: avgLat, lng: avgLng };
+    } else {
+      return { lat: 37.5665, lng: 126.978 }; // 서울시청 기본값
+    }
+  };
+
+  const fitBoundsToMarkers = () => {
+    if (!mapRef.current || !capsuleList || capsuleList.length === 0) return;
+
+    const bounds = new kakao.maps.LatLngBounds();
+
+    capsuleList.forEach((item) => {
+      bounds.extend(
+        new kakao.maps.LatLng(
+          item.capsule.unlock.location.locationLat,
+          item.capsule.unlock.location.locationLng
+        )
+      );
+    });
+
+    mapRef.current.setBounds(bounds);
+  };
+
   return (
     <>
       <div className="h-full flex flex-col gap-4">
         <div className="flex-1 flex gap-4 min-h-0">
-          <div className="w-full h-full overflow-y-auto space-y-4 pr-2"></div>
+          <div className="w-full h-full overflow-y-auto space-y-4 pr-2">
+            <Map
+              center={mapCenter()}
+              style={{ width: "100%", height: "100%" }}
+              onCreate={(map) => {
+                mapRef.current = map;
+                fitBoundsToMarkers();
+              }}
+            >
+              {/* 경로 마커들 */}
+              {capsuleList
+                ? capsuleList.map((item, index) => (
+                    <CustomOverlayMap
+                      key={item.capsule.capsuleId}
+                      position={{
+                        lat: item.capsule.unlock.location.locationLat,
+                        lng: item.capsule.unlock.location.locationLng,
+                      }}
+                      zIndex={capsuleList?.length - index}
+                    >
+                      <div className="group relative flex flex-col items-center">
+                        {/* 마커 */}
+                        <div className="peer w-10 h-10 rounded-full bg-primary-2 border-2 border-white shadow-lg flex items-center justify-center">
+                          {storytrackType === "SEQUENTIAL" ? (
+                            <span className="text-white text-xs font-semibold">
+                              {index + 1}
+                            </span>
+                          ) : (
+                            <div className="w-3 h-3 rounded-full bg-primary" />
+                          )}
+                        </div>
+                        {/* 제목 툴팁 (호버 시) */}
+                        <div className="absolute bottom-full mb-2 p-3 text-sm rounded-lg shadow bg-white opacity-0 peer-hover:z-100 peer-hover:opacity-100 transition-opacity">
+                          {item.capsule.capsuleTitle}
+                        </div>
+                      </div>
+                    </CustomOverlayMap>
+                  ))
+                : ""}
+            </Map>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/dashboard/storyTrack/detail/TrackOverview.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackOverview.tsx
@@ -1,6 +1,47 @@
-import { ListOrdered, Route, Users, X } from "lucide-react";
+"use client";
+
+import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ListOrdered,
+  Pencil,
+  Play,
+  Route,
+  Shuffle,
+  Trash2,
+  Users,
+  X,
+} from "lucide-react";
+import { useParams } from "next/navigation";
+import { useState } from "react";
 
 export default function TrackOverview() {
+  const params = useParams();
+  const storytrackId =
+    typeof params.trackId === "string" ? params.trackId : undefined;
+  const [page] = useState(0);
+  const [size] = useState(100);
+
+  // 스토리트랙 상세 조회
+  const {
+    data: trackData,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["storyTrackDetail", storytrackId],
+    queryFn: async ({ signal }) => {
+      return await storyTrackApi.storyTrackDetail(
+        { storytrackId, page, size },
+        signal
+      );
+    },
+    enabled: !!storytrackId,
+  });
+
+  if (isError) {
+    console.error(error);
+    return <div>{String(error)}</div>;
+  }
   return (
     <>
       <div className="p-6 flex flex-col h-full">
@@ -8,24 +49,35 @@ export default function TrackOverview() {
           <div className="space-y-6">
             <div className="space-y-4">
               {/* 제목 */}
-              <div className="text-xl">서울 한강 이야기</div>
+              <div className="text-xl">{trackData?.data.title}</div>
               {/* 요약 */}
               <div className="flex gap-2">
                 <div className="bg-primary-5/60 border-2 border-primary-4 rounded-full px-2 py-1 flex items-center gap-1 text-primary-2">
-                  <ListOrdered size={16} />
-                  <span className="text-sm">순서대로</span>
-                  {/* <Shuffle size={18} />
-                  <span>순서무관</span> */}
+                  {trackData?.data.storytrackType === "SEQUENTIAL" ? (
+                    <>
+                      <ListOrdered size={16} />
+                      <span className="text-sm">순서대로</span>
+                    </>
+                  ) : (
+                    <>
+                      <Shuffle size={18} />
+                      <span className="text-sm">순서무관</span>
+                    </>
+                  )}
                 </div>
 
                 <div className="bg-button-hover border-2 border-outline rounded-full px-2 flex items-center gap-1 text-text-2">
                   <Route size={16} />
-                  <span className="text-sm">5개 장소</span>
+                  <span className="text-sm">
+                    {trackData?.data.totalSteps}개 장소
+                  </span>
                 </div>
               </div>
               <div className="flex items-center gap-1 text-text-3">
                 <Users size={16} />
-                <span className="text-sm">123명 참여 중</span>
+                <span className="text-sm">
+                  {trackData?.data.totalParticipant}명 참여 중
+                </span>
               </div>
             </div>
 
@@ -38,22 +90,19 @@ export default function TrackOverview() {
               <div className="text-sm space-y-2">
                 <p>트랙 소개</p>
                 <p className="text-text-3 break-keep">
-                  한강을 따라 펼쳐지는 추억의 여정. 여의도부터 뚝섬까지, 각
-                  장소마다 숨겨진 이야기를 발견하세요. 이 스토리트랙은 한강의
-                  아름다운 풍경과 함께 서울의 현대사가 담긴 특별한 장소들을
-                  탐방합니다. 각 지점마다 준비된 편지를 통해 그 장소만의
-                  이야기를 만나보세요.
+                  {/* api 속성 추가 필요 */}
+                  {trackData?.data.descripton}
                 </p>
               </div>
 
               {/* 작성자 */}
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-full bg-black flex items-center justify-center text-white">
-                  홍
+                  {trackData?.data.createrNickname.slice(0, 1)}
                 </div>
                 <div className="flex flex-col">
                   {/* <span className="text-sm text-text-4">만든 사람</span> */}
-                  <span>홍길동</span>
+                  <span>{trackData?.data.createrNickname}</span>
                 </div>
               </div>
             </div>
@@ -62,25 +111,35 @@ export default function TrackOverview() {
             <div className="w-full h-px bg-outline"></div>
 
             {/* 생성일 */}
-            <span className="text-text-3">생성일: 2025.12.01</span>
+            <span className="text-text-3 text-sm">
+              생성일: {trackData?.data.createdAt.slice(0, 10)}
+            </span>
           </div>
 
           {/* 버튼 */}
           <div className="w-full">
-            {/* <button className="cursor-pointer bg-text-2 hover:bg-text-3 text-white px-4 py-2 rounded-xl flex items-center gap-2">
-            <Pencil />
-            수정
-          </button>
-          <button className="cursor-pointer bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-xl flex items-center gap-2">
-            <Trash2 />
-            삭제
-          </button> */}
-            <button className="w-full flex items-center justify-center gap-2 cursor-pointer bg-primary hover:bg-primary-3 text-white px-4 py-3 rounded-xl ">
-              <X />
-              <span>참여 중지</span>
-              {/* <Play />
-              <span>참여하기</span> */}
-            </button>
+            {trackData?.data.memberType === "CREATOR" ? (
+              <div className="grid grid-cols-2 gap-2">
+                <button className="cursor-pointer justify-center bg-text-2 hover:bg-text-3 text-white px-4 py-2 rounded-xl flex items-center gap-2">
+                  <Pencil />
+                  수정
+                </button>
+                <button className="cursor-pointer justify-center bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-xl flex items-center gap-2">
+                  <Trash2 />
+                  삭제
+                </button>
+              </div>
+            ) : trackData?.data.memberType === "NOT_JOINED" ? (
+              <button className="w-full flex items-center justify-center gap-2 cursor-pointer bg-primary hover:bg-primary-3 text-white px-4 py-3 rounded-xl ">
+                <Play />
+                <span>참여하기</span>
+              </button>
+            ) : (
+              <button className="w-full flex items-center justify-center gap-2 cursor-pointer bg-primary hover:bg-primary-3 text-white px-4 py-3 rounded-xl ">
+                <X />
+                <span>참여 중지</span>
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/dashboard/storyTrack/detail/TrackProgress.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackProgress.tsx
@@ -2,14 +2,71 @@
 
 import { useState } from "react";
 import { ChevronDown, ChevronUp, Flag } from "lucide-react";
+import { useParams } from "next/navigation";
+import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
+import { useQuery } from "@tanstack/react-query";
 
 export default function TrackProgress() {
   const [collapsed, setCollapsed] = useState(true);
 
-  const completed = 2;
-  const total = 5;
-  const percent = Math.round((completed / total) * 100);
+  const params = useParams();
+  const storytrackId =
+    typeof params.trackId === "string" ? params.trackId : undefined;
+  const [page] = useState(0);
+  const [size] = useState(100);
 
+  // 스토리트랙 상세 조회
+  const {
+    data: detailData,
+    isError: isDetailError,
+    error: detailError,
+  } = useQuery({
+    queryKey: ["storyTrackDetail", storytrackId],
+    queryFn: async ({ signal }) => {
+      return await storyTrackApi.storyTrackDetail(
+        { storytrackId, page, size },
+        signal
+      );
+    },
+    enabled: !!storytrackId,
+  });
+
+  // 스토리트랙 상세 조회
+  const {
+    data: progressData,
+    isError: isProgressError,
+    error: progressError,
+  } = useQuery({
+    queryKey: ["storyTrackProgress", storytrackId],
+    queryFn: async ({ signal }) => {
+      return await storyTrackApi.storyTrackProgress({ storytrackId }, signal);
+    },
+    enabled: !!storytrackId,
+  });
+
+  const completed = progressData?.data.completedSteps;
+  const total = detailData?.data.totalSteps;
+  const percent =
+    typeof completed === "number" && typeof total === "number" && total > 0
+      ? Math.round((completed / total) * 100)
+      : 0;
+
+  const lastCompletedCapsule =
+    detailData?.data.paths.content[
+      progressData ? progressData?.data.lastCompletedStep : 0
+    ];
+
+  if (isDetailError || isProgressError) {
+    return (
+      <div>
+        {progressError
+          ? "진행 상세 조회 API 에러: " + String(progressError)
+          : "" + detailError
+          ? "스토리트랙 상세 조회 API 에러: " + String(detailError)
+          : ""}
+      </div>
+    );
+  }
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
@@ -30,7 +87,7 @@ export default function TrackProgress() {
             <div className="w-28 h-1.5 bg-outline rounded-full overflow-hidden">
               <div
                 className="h-full bg-primary-2"
-                style={{ width: `${(completed / total) * 100}%` }}
+                style={{ width: `${percent}%` }}
               />
             </div>
 
@@ -60,11 +117,13 @@ export default function TrackProgress() {
             <div className="flex gap-4">
               <div className="flex-1 border border-outline rounded-xl p-4 flex flex-col gap-1">
                 <span className="text-xs text-text-3">완료</span>
-                <span className="text-xl">{completed}</span>
+                <span className="text-xl">{completed ?? 0}</span>
               </div>
               <div className="flex-1 border border-outline rounded-xl p-4 flex flex-col gap-1">
                 <span className="text-xs text-text-3">남은 장소</span>
-                <span className="text-xl">{total - completed}</span>
+                <span className="text-xl">
+                  {typeof total === "number" ? total - (completed ?? 0) : "-"}
+                </span>
               </div>
               <div className="flex-1 border border-outline rounded-xl p-4 flex flex-col gap-1">
                 <span className="text-xs text-text-3">전체 장소</span>
@@ -79,9 +138,11 @@ export default function TrackProgress() {
                 <span>다음 목적지</span>
               </div>
               <div className="space-y-1">
-                <p className="text-lg">잠실 한강공원</p>
+                <p className="text-lg">
+                  {lastCompletedCapsule?.capsule.capsuleTitle}
+                </p>
                 <p className="text-sm text-text-3">
-                  서울특별시 송파구 올림픽로 139
+                  {lastCompletedCapsule?.capsule.unlock.location.address}
                 </p>
               </div>
             </div>
@@ -90,11 +151,15 @@ export default function TrackProgress() {
             <div className="w-full border border-outline rounded-xl p-4 flex">
               <div className="flex-1 flex flex-col gap-0.5">
                 <span className="text-text-3 text-sm">시작일</span>
-                <span>2024. 12. 20</span>
+                <span>{progressData?.data.createdAt.slice(0, 10)}</span>
               </div>
               <div className="flex-1 flex flex-col gap-0.5">
                 <span className="text-text-3 text-sm">최근 방문</span>
-                <span>2024. 12. 21</span>
+                <span>
+                  {progressData?.data.completedAt
+                    ? progressData?.data.completedAt.slice(0, 10)
+                    : "-"}
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/dashboard/storyTrack/detail/TrackProgress.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackProgress.tsx
@@ -31,7 +31,7 @@ export default function TrackProgress() {
     enabled: !!storytrackId,
   });
 
-  // 스토리트랙 상세 조회
+  // 스토리트랙 진행 상세 조회
   const {
     data: progressData,
     isError: isProgressError,
@@ -137,24 +137,32 @@ export default function TrackProgress() {
                 <Flag size={20} className="text-primary" />
                 <span>다음 목적지</span>
               </div>
-              <div className="space-y-1">
-                <p className="text-lg">
-                  {lastCompletedCapsule?.capsule.capsuleTitle}
-                </p>
-                <p className="text-sm text-text-3">
-                  {lastCompletedCapsule?.capsule.unlock.location.address}
-                </p>
-              </div>
+              {detailData?.data.memberType === "COMPLETED" ? (
+                <div className="space-y-1">
+                  <p className="text-sm text-text-3">
+                    모든 편지를 열람했습니다.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  <p className="text-lg">
+                    {lastCompletedCapsule?.capsule.capsuleTitle}
+                  </p>
+                  <p className="text-sm text-text-3">
+                    {lastCompletedCapsule?.capsule.unlock.location.address}
+                  </p>
+                </div>
+              )}
             </div>
 
             {/* 시작일 / 최근 방문 */}
             <div className="w-full border border-outline rounded-xl p-4 flex">
               <div className="flex-1 flex flex-col gap-0.5">
-                <span className="text-text-3 text-sm">시작일</span>
+                <span className="text-text-3 text-sm">시작 날짜</span>
                 <span>{progressData?.data.createdAt.slice(0, 10)}</span>
               </div>
               <div className="flex-1 flex flex-col gap-0.5">
-                <span className="text-text-3 text-sm">최근 방문</span>
+                <span className="text-text-3 text-sm">완료 날짜</span>
                 <span>
                   {progressData?.data.completedAt
                     ? progressData?.data.completedAt.slice(0, 10)

--- a/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
@@ -1,17 +1,49 @@
 import Logo from "@/components/common/Logo";
+import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
+import { useQuery } from "@tanstack/react-query";
 import { Check, CheckCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 type TrackRouteProps = {
+  memberType?: string;
   storytrackType?: "SEQUENTIAL" | "PARALLEL";
   capsuleList?: StoryTrackPathItem[];
+  completedCapsuleList?: number[];
 };
 
 export default function TrackRoute({
+  memberType,
   storytrackType,
   capsuleList,
+  completedCapsuleList,
 }: TrackRouteProps) {
   const router = useRouter();
+
+  //스토리트랙 id
+  const params = useParams();
+  const storytrackId =
+    typeof params.trackId === "string" ? params.trackId : undefined;
+
+  // 스토리트랙 진행 상세 조회
+  const {
+    data: progressData,
+    isError: isProgressError,
+    error: progressError,
+  } = useQuery({
+    queryKey: ["storyTrackProgress", storytrackId],
+    queryFn: async ({ signal }) => {
+      return await storyTrackApi.storyTrackProgress({ storytrackId }, signal);
+    },
+    refetchOnMount: false,
+    enabled:
+      !!storytrackId &&
+      (memberType === "PARTICIPANT" || memberType === "COMPLETED"),
+  });
+
+  if (isProgressError) {
+    console.error(progressError);
+    return <div>{String(progressError)}</div>;
+  }
 
   return (
     <div className="h-full flex flex-col gap-4">
@@ -19,8 +51,75 @@ export default function TrackRoute({
 
       <div className="flex gap-4 lg:min-h-0">
         <div className="w-full h-full overflow-y-auto space-y-4 pr-2">
-          {storytrackType === "SEQUENTIAL"
+          {memberType === "PARTICIPANT" || memberType === "COMPLETED"
             ? capsuleList?.map((item) => (
+                <>
+                  {completedCapsuleList?.includes(item.capsule.capsuleId) ? (
+                    <button
+                      key={item.capsule.capsuleId}
+                      className="cursor-pointer w-full rounded-xl border border-green-400 p-6 flex items-start gap-4 bg-green-50"
+                      onClick={() => {
+                        router.push(`?id=${item.capsule.capsuleId}`);
+                      }}
+                    >
+                      <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-green-600 text-white">
+                        <CheckCircle />
+                      </div>
+                      <div className="space-y-2">
+                        <div className="flex flex-col items-start text-left">
+                          <p className="text-lg">{item.capsule.capsuleTitle}</p>
+                          <p className="text-sm text-text-2">
+                            {item.capsule.unlock.location.address}
+                          </p>
+                        </div>
+                        {/* <p className="flex gap-1 text-xs text-green-600">
+                          <Check size={16} />
+                          <span>완료: 2024. 12. 21. 오전 10:15:00</span>
+                        </p> */}
+                      </div>
+                    </button>
+                  ) : (progressData?.data.lastCompletedStep ?? 0) + 1 <
+                      item.stepOrder && storytrackType === "SEQUENTIAL" ? (
+                    <button
+                      disabled
+                      className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 bg-button-hover disabled:cursor-not-allowed"
+                    >
+                      <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+                        {item.stepOrder}
+                      </div>
+                      <div className="flex flex-col items-start text-left">
+                        <p className="text-lg">{item.capsule.capsuleTitle}</p>
+                        <p className="text-sm text-text-2">
+                          {item.capsule.unlock.location.address}
+                        </p>
+                      </div>
+                    </button>
+                  ) : (
+                    <button
+                      key={item.capsule.capsuleId}
+                      className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover"
+                      onClick={() => {
+                        router.push(`?id=${item.capsule.capsuleId}`);
+                      }}
+                    >
+                      <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+                        {storytrackType === "SEQUENTIAL" ? (
+                          item.stepOrder
+                        ) : (
+                          <Logo className="text-white w-6 h-6" />
+                        )}
+                      </div>
+                      <div className="flex flex-col items-start text-left">
+                        <p className="text-lg">{item.capsule.capsuleTitle}</p>
+                        <p className="text-sm text-text-2">
+                          {item.capsule.unlock.location.address}
+                        </p>
+                      </div>
+                    </button>
+                  )}
+                </>
+              ))
+            : capsuleList?.map((item) => (
                 <button
                   key={item.capsule.capsuleId}
                   className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover"
@@ -29,26 +128,11 @@ export default function TrackRoute({
                   }}
                 >
                   <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                    {item.stepOrder}
-                  </div>
-                  <div className="flex flex-col items-start text-left">
-                    <p className="text-lg">{item.capsule.capsuleTitle}</p>
-                    <p className="text-sm text-text-2">
-                      {item.capsule.unlock.location.address}
-                    </p>
-                  </div>
-                </button>
-              ))
-            : capsuleList?.map((item) => (
-                <button
-                  key={item.capsule.capsuleId}
-                  className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover"
-                  onClick={() => {
-                    router.push(`/dashboard/map?id=${item.capsule.capsuleId}`);
-                  }}
-                >
-                  <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                    <Logo className="text-white w-6 h-6" />
+                    {storytrackType === "SEQUENTIAL" ? (
+                      item.stepOrder
+                    ) : (
+                      <Logo className="text-white w-6 h-6" />
+                    )}
                   </div>
                   <div className="flex flex-col items-start text-left">
                     <p className="text-lg">{item.capsule.capsuleTitle}</p>

--- a/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
@@ -1,16 +1,67 @@
 import Logo from "@/components/common/Logo";
 import { Check, CheckCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
 
-export default function TrackRoute() {
+type TrackRouteProps = {
+  storytrackType?: "SEQUENTIAL" | "PARALLEL";
+  capsuleList?: StoryTrackPathItem[];
+};
+
+export default function TrackRoute({
+  storytrackType,
+  capsuleList,
+}: TrackRouteProps) {
+  const router = useRouter();
+
   return (
     <div className="h-full flex flex-col gap-4">
       <p className="text-base lg:text-xl">경로 상세</p>
 
       <div className="flex gap-4 lg:min-h-0">
         <div className="w-full h-full overflow-y-auto space-y-4 pr-2">
+          {storytrackType === "SEQUENTIAL"
+            ? capsuleList?.map((item) => (
+                <button
+                  key={item.capsule.capsuleId}
+                  className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover"
+                  onClick={() => {
+                    router.push(`?id=${item.capsule.capsuleId}`);
+                  }}
+                >
+                  <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+                    {item.stepOrder}
+                  </div>
+                  <div className="flex flex-col items-start text-left">
+                    <p className="text-lg">{item.capsule.capsuleTitle}</p>
+                    <p className="text-sm text-text-2">
+                      {item.capsule.unlock.location.address}
+                    </p>
+                  </div>
+                </button>
+              ))
+            : capsuleList?.map((item) => (
+                <button
+                  key={item.capsule.capsuleId}
+                  className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover"
+                  onClick={() => {
+                    router.push(`/dashboard/map?id=${item.capsule.capsuleId}`);
+                  }}
+                >
+                  <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+                    <Logo className="text-white w-6 h-6" />
+                  </div>
+                  <div className="flex flex-col items-start text-left">
+                    <p className="text-lg">{item.capsule.capsuleTitle}</p>
+                    <p className="text-sm text-text-2">
+                      {item.capsule.unlock.location.address}
+                    </p>
+                  </div>
+                </button>
+              ))}
+
           {/* 순서대로 => 번호 / 순서x => 로고 */}
           {/* 순서 버전 */}
-          <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
+          {/* <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
             <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
               1
             </div>
@@ -20,10 +71,10 @@ export default function TrackRoute() {
                 서울특별시 송파구 올림픽로 139
               </p>
             </div>
-          </button>
+          </button> */}
 
           {/* 순서x 버전 */}
-          <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
+          {/* <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
             <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
               <Logo className="text-white w-6 h-6" />
             </div>
@@ -33,10 +84,10 @@ export default function TrackRoute() {
                 서울특별시 송파구 올림픽로 139
               </p>
             </div>
-          </button>
+          </button> */}
 
           {/* 편지 확인 버전 */}
-          <button className="cursor-pointer w-full rounded-xl border border-green-400 p-6 flex items-start gap-4 bg-green-50">
+          {/* <button className="cursor-pointer w-full rounded-xl border border-green-400 p-6 flex items-start gap-4 bg-green-50">
             <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-green-600 text-white">
               <CheckCircle />
             </div>
@@ -52,10 +103,10 @@ export default function TrackRoute() {
                 <span>완료: 2024. 12. 21. 오전 10:15:00</span>
               </p>
             </div>
-          </button>
+          </button> */}
 
           {/* 순서 버전에서 아직 차례가 되지 않은 것들 */}
-          <button
+          {/* <button
             disabled
             className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 bg-button-hover disabled:cursor-not-allowed"
           >
@@ -68,7 +119,7 @@ export default function TrackRoute() {
                 서울특별시 영등포구 여의동로 330
               </p>
             </div>
-          </button>
+          </button> */}
         </div>
       </div>
     </div>

--- a/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackRoute.tsx
@@ -1,10 +1,12 @@
 import Logo from "@/components/common/Logo";
 import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
+import { distanceMeters } from "@/lib/hooks/distanceMeters";
 import { useQuery } from "@tanstack/react-query";
-import { Check, CheckCircle } from "lucide-react";
+import { Check, CheckCircle, Lock } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 
 type TrackRouteProps = {
+  myLocation: { lat: number; lng: number } | null;
   memberType?: string;
   storytrackType?: "SEQUENTIAL" | "PARALLEL";
   capsuleList?: StoryTrackPathItem[];
@@ -12,6 +14,7 @@ type TrackRouteProps = {
 };
 
 export default function TrackRoute({
+  myLocation,
   memberType,
   storytrackType,
   capsuleList,
@@ -52,9 +55,12 @@ export default function TrackRoute({
       <div className="flex gap-4 lg:min-h-0">
         <div className="w-full h-full overflow-y-auto space-y-4 pr-2">
           {memberType === "PARTICIPANT" || memberType === "COMPLETED"
-            ? capsuleList?.map((item) => (
+            ? //열람, 잠금 여부에 따른 style을 적용한 item
+              //해당 스토리트랙에 참여한 사용자와 완료한 사용자에게 보여짐.
+              capsuleList?.map((item) => (
                 <>
                   {completedCapsuleList?.includes(item.capsule.capsuleId) ? (
+                    // 완료한 item style
                     <button
                       key={item.capsule.capsuleId}
                       className="cursor-pointer w-full rounded-xl border border-green-400 p-6 flex items-start gap-4 bg-green-50"
@@ -80,6 +86,7 @@ export default function TrackRoute({
                     </button>
                   ) : (progressData?.data.lastCompletedStep ?? 0) + 1 <
                       item.stepOrder && storytrackType === "SEQUENTIAL" ? (
+                    // 열람 불가능한 item style
                     <button
                       disabled
                       className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 bg-button-hover disabled:cursor-not-allowed"
@@ -95,31 +102,45 @@ export default function TrackRoute({
                       </div>
                     </button>
                   ) : (
+                    // 기본 item style
                     <button
                       key={item.capsule.capsuleId}
-                      className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover"
+                      className="group cursor-pointer w-full rounded-xl border border-outline p-6 flex items-center justify-between gap-4 hover:bg-button-hover"
                       onClick={() => {
                         router.push(`?id=${item.capsule.capsuleId}`);
                       }}
                     >
-                      <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-                        {storytrackType === "SEQUENTIAL" ? (
-                          item.stepOrder
-                        ) : (
-                          <Logo className="text-white w-6 h-6" />
+                      <div className="flex gap-4">
+                        <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
+                          {storytrackType === "SEQUENTIAL" ? (
+                            item.stepOrder
+                          ) : (
+                            <Logo className="text-white w-6 h-6" />
+                          )}
+                        </div>
+                        <div className="flex flex-col items-start text-left">
+                          <p className="text-lg">{item.capsule.capsuleTitle}</p>
+                          <p className="text-sm text-text-2">
+                            {item.capsule.unlock.location.address}
+                          </p>
+                        </div>
+                      </div>
+                      {myLocation &&
+                        distanceMeters(myLocation, {
+                          lat: item.capsule.unlock.location.locationLat,
+                          lng: item.capsule.unlock.location.locationLng,
+                        }) >= 50 && (
+                          <div className="hidden group-hover:block">
+                            <Lock />
+                          </div>
                         )}
-                      </div>
-                      <div className="flex flex-col items-start text-left">
-                        <p className="text-lg">{item.capsule.capsuleTitle}</p>
-                        <p className="text-sm text-text-2">
-                          {item.capsule.unlock.location.address}
-                        </p>
-                      </div>
                     </button>
                   )}
                 </>
               ))
-            : capsuleList?.map((item) => (
+            : //열람, 잠금 여부에 따른 style을 적용하지 않은 item
+              //해당 스토리트랙에 참여하지 않은 사용자와 스토리트랙 생성자에게 보여짐.
+              capsuleList?.map((item) => (
                 <button
                   key={item.capsule.capsuleId}
                   className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover"
@@ -142,68 +163,6 @@ export default function TrackRoute({
                   </div>
                 </button>
               ))}
-
-          {/* 순서대로 => 번호 / 순서x => 로고 */}
-          {/* 순서 버전 */}
-          {/* <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
-            <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-              1
-            </div>
-            <div className="flex flex-col items-start text-left">
-              <p className="text-lg">잠실 한강공원</p>
-              <p className="text-sm text-text-2">
-                서울특별시 송파구 올림픽로 139
-              </p>
-            </div>
-          </button> */}
-
-          {/* 순서x 버전 */}
-          {/* <button className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 hover:bg-button-hover">
-            <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-              <Logo className="text-white w-6 h-6" />
-            </div>
-            <div className="flex flex-col items-start text-left">
-              <p className="text-lg">잠실 한강공원</p>
-              <p className="text-sm text-text-2">
-                서울특별시 송파구 올림픽로 139
-              </p>
-            </div>
-          </button> */}
-
-          {/* 편지 확인 버전 */}
-          {/* <button className="cursor-pointer w-full rounded-xl border border-green-400 p-6 flex items-start gap-4 bg-green-50">
-            <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-green-600 text-white">
-              <CheckCircle />
-            </div>
-            <div className="space-y-2">
-              <div className="flex flex-col items-start text-left">
-                <p className="text-lg">뚝섬 한강공원</p>
-                <p className="text-sm text-text-2">
-                  서울특별시 광진구 강변북로 139
-                </p>
-              </div>
-              <p className="flex gap-1 text-xs text-green-600">
-                <Check size={16} />
-                <span>완료: 2024. 12. 21. 오전 10:15:00</span>
-              </p>
-            </div>
-          </button> */}
-
-          {/* 순서 버전에서 아직 차례가 되지 않은 것들 */}
-          {/* <button
-            disabled
-            className="cursor-pointer w-full rounded-xl border border-outline p-6 flex items-start gap-4 bg-button-hover disabled:cursor-not-allowed"
-          >
-            <div className="flex-none w-12 h-12 rounded-full flex items-center justify-center bg-text text-white">
-              3
-            </div>
-            <div className="flex flex-col items-start text-left">
-              <p className="text-lg">여의도 한강공원</p>
-              <p className="text-sm text-text-2">
-                서울특별시 영등포구 여의동로 330
-              </p>
-            </div>
-          </button> */}
         </div>
       </div>
     </div>

--- a/src/lib/api/dashboard/storyTrack.ts
+++ b/src/lib/api/dashboard/storyTrack.ts
@@ -132,4 +132,46 @@ export const storyTrackApi = {
       { signal }
     );
   },
+
+  /**
+   * 스토리트랙 상세 조회
+   * @param params 캡슐id, 페이지네이션 파라미터
+   */
+  storyTrackDetail: (
+    params?: { storytrackId?: string; page?: number; size?: number },
+    signal?: AbortSignal
+  ) => {
+    const storytrackId = params?.storytrackId;
+    const page = params?.page ?? 0;
+    const size = params?.size ?? 100;
+
+    const sp = new URLSearchParams();
+    sp.set("storytrackId", String(storytrackId));
+    sp.set("page", String(page));
+    sp.set("size", String(size));
+
+    return apiFetchRaw<StoryTrackDetailResponse>(
+      `/api/v1/storytrack/dashboard?${sp.toString()}`,
+      { method: "GET", signal }
+    );
+  },
+
+  /**
+   * 스토리트랙 진행 상세 조회
+   * @param params 캡슐id 파라미터
+   */
+  storyTrackProgress: (
+    params?: { storytrackId?: string },
+    signal?: AbortSignal
+  ) => {
+    const storytrackId = params?.storytrackId;
+
+    const sp = new URLSearchParams();
+    sp.set("storytrackId", String(storytrackId));
+
+    return apiFetchRaw<StoryTrackProgressResponse>(
+      `/api/v1/storytrack/participant/progress?${sp.toString()}`,
+      { method: "GET", signal }
+    );
+  },
 };

--- a/src/lib/hooks/distanceMeters.ts
+++ b/src/lib/hooks/distanceMeters.ts
@@ -1,0 +1,19 @@
+type LatLng = { lat: number; lng: number };
+
+export function distanceMeters(a: LatLng, b: LatLng) {
+  const R = 6371e3;
+  const toRad = (v: number) => (v * Math.PI) / 180;
+
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+
+  const x =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+  return R * c;
+}

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -84,6 +84,7 @@ type PageEnvelope<T> = {
 /** 공개 전체 스토리트랙   */
 type PublicStoryTrackItem = {
   storytrackId: number;
+  creatorNickname: string;
   title: string;
   description: string;
   trackType: string;
@@ -129,6 +130,7 @@ type MineStoryTrackItem = {
 type StoryTrackJoinedItem = {
   memberId: number;
   storytrackId: number;
+  creatorNickname: string;
   title: string;
   description: string;
   trackType: string;
@@ -185,3 +187,62 @@ type JoinedStoryTrackListResponse = ApiEnvelope<
 >;
 type MineStoryTrackListResponse = ApiEnvelope<PageEnvelope<MineStoryTrackItem>>;
 type StoryTrackMineListResponse = ApiResponse<StoryTrackMineListPage>;
+
+// 스토리트랙 상세 조회
+type StoryTrackDetailItem = {
+  storytrackId: number;
+  createrNickname: string;
+  title: string;
+  descripton: string;
+  storytrackType: "SEQUENTIAL" | "PARALLEL";
+  isPublic: number; // 0 | 1
+  totalSteps: number;
+  createdAt: string;
+  totalParticipant: number;
+  completeParticipant: number;
+  memberType: "CREATOR" | "NOT_JOINED" | "JOINED";
+  paths: StoryTrackPaths;
+};
+
+type StoryTrackPaths = {
+  content: StoryTrackPathItem[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  last: boolean;
+};
+
+type StoryTrackPathItem = {
+  stepOrder: number;
+  capsule: {
+    capsuleId: number;
+    createrNickname: string;
+    capsuleTitle: string;
+    capsuleContent: string;
+    unlockType: string;
+    unlock: {
+      unlockAt: string;
+      locationName: string;
+      location: {
+        address: string;
+        locationLat: number;
+        locationLng: number;
+      };
+      currentViewCount: number;
+    };
+  };
+};
+
+type StoryTrackDetailResponse = ApiEnvelope<StoryTrackDetailItem>;
+
+//스토리트랙 진행 상세 조회
+type StoryTrackProgressItem = {
+  storytrackId: number;
+  completedSteps: number;
+  lastCompletedStep: number;
+  completedAt: string;
+  createdAt: string;
+};
+
+type StoryTrackProgressResponse = ApiEnvelope<StoryTrackProgressItem>;

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -200,8 +200,9 @@ type StoryTrackDetailItem = {
   createdAt: string;
   totalParticipant: number;
   completeParticipant: number;
-  memberType: "CREATOR" | "NOT_JOINED" | "JOINED";
+  memberType: "CREATOR" | "NOT_JOINED" | "PARTICIPANT" | "COMPLETED";
   paths: StoryTrackPaths;
+  completedCapsuleId: number[];
 };
 
 type StoryTrackPaths = {


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
스토리트랙 세부 조회 기능 구현

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #93 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 스토리트랙 세부 조회 페이지 내 api 연결
- [x] 스토리트랙 캡슐 열람 가능 여부 hover시 보이도록 처리 
- [x] 거리 계산 hook으로 분리
- [x] 스토리트랙 캡슐 상태에 따른 style 수정 필요

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

- 스토리트랙 캡슐 조회는 api가 달라서 캡슐 세부 열람 모달 수정이 필요한 상태입니다. 
 => 위 사항은 pr 분리하는 것이 좋을 것 같아서 pr 따로 올리겠습니다.
- 스토리트랙에 참여한 사람인데도 memberType이 NOT_JOINED로 나오는 이슈가 있어 api 수정이 되면 수정할 예정입니다
 => 수정 완료
- 스토리트랙 세부 페이지에서 경로탭의 경우 열람한 캡슐, 열람 불가능한 캡슐의 style지정 또한 api 수정이 된 후에 수정할 예정입니다
 => 수정 완료

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

memberType이 PARTICIPANT, COMPLETED 일때만 캡슐 열람 상태에 따른 style을 적용했습니다.
이외의 memberType일 때는 기본 style의 리스트만 나옵니다. (캡슐 조회 onClick은 넣을지 말지 고민중)

스토리트랙 캡슐 열람 가능 여부 또한 memberType이 PARTICIPANT, COMPLETED인 사용자 한정으로 나옵니다.
그리고 완료되었거나, 열람 차례가 되지 않은 캡슐은 열람 가능 여부가 보이지 않게 처리했습니다.
