### PR TITLE
[#102] feat(view-count): 공개편지 선착순 입력 폼 구현 및 선착순 조회 실패 에러 처리 구현

### DIFF
--- a/src/components/capsule/detail/LetterDetailView.tsx
+++ b/src/components/capsule/detail/LetterDetailView.tsx
@@ -9,6 +9,7 @@ import LetterLockedView from "./LetterLockedView";
 import { guestCapsuleApi } from "@/lib/api/capsule/guestCapsule";
 import { useRouter } from "next/navigation";
 import { CircleAlert } from "lucide-react";
+import { getErrorMessage } from "@/lib/utils/errorHandler";
 
 type LatLng = { lat: number; lng: number };
 
@@ -99,7 +100,7 @@ export default function LetterDetailView({
     return `${lat},${lng}`;
   }, [currentLocation]);
 
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["capsuleRead", capsuleId, password, locationKey],
     queryFn: async ({ signal }) => {
       const unlockAt = new Date().toISOString();
@@ -221,33 +222,43 @@ export default function LetterDetailView({
     );
   }
 
+  // 에러 메시지 가져오기
+  const errorMessage = getErrorMessage(error);
+
   // 네트워크/서버 레벨 에러 (응답 자체가 없음)
   if (isError || !data) {
     return (
       <div className="w-full h-full flex items-center justify-center p-8">
         <div className="w-full max-w-md rounded-2xl border border-outline bg-white p-6 text-center space-y-4">
-          <div className="text-lg font-medium">서버 오류가 발생했어요</div>
-          <p className="text-sm text-text-2">
-            잠시 후 다시 시도해 주세요.
-            <br />
-            문제가 계속되면 네트워크 상태를 확인해 주세요.
+          <div className="text-lg font-medium">
+            {errorMessage?.title ?? "서버 오류가 발생했어요"}
+          </div>
+          <p className="text-sm text-text-2 whitespace-pre-line">
+            {errorMessage?.description ??
+              "잠시 후 다시 시도해 주세요.\n문제가 계속되면 네트워크 상태를 확인해 주세요."}
           </p>
 
           <div className="flex gap-2 justify-center pt-2">
             <button
               type="button"
               onClick={handleBack}
-              className="cursor-pointer px-4 py-2 rounded-lg border border-outline text-text hover:bg-button-hover"
+              className={`cursor-pointer px-4 py-2 rounded-lg ${
+                errorMessage?.showRetry === false
+                  ? "bg-primary text-white hover:opacity-90"
+                  : "border border-outline text-text hover:bg-button-hover"
+              }`}
             >
               뒤로 가기
             </button>
-            <button
-              type="button"
-              onClick={() => refetch()}
-              className="cursor-pointer px-4 py-2 rounded-lg bg-primary text-white hover:opacity-90"
-            >
-              다시 시도
-            </button>
+            {errorMessage?.showRetry !== false && (
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="cursor-pointer px-4 py-2 rounded-lg bg-primary text-white hover:opacity-90"
+              >
+                다시 시도
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -760,37 +760,40 @@ export default function WriteForm({
         )}
 
         {visibility === "PUBLIC" && (
-          <WriteDiv title="선착순 인원">
-            <div className="flex flex-col gap-2">
-              <div
-                className="flex items-center justify-between cursor-pointer"
-                onClick={() => {
-                  setIsMaxViewCountExpanded((prev) => !prev);
-                  if (isMaxViewCountExpanded) {
-                    setMaxViewCount("");
-                  }
-                }}
-              >
-                <span className="text-sm">선착순 인원</span>
-                {isMaxViewCountExpanded ? (
-                  <Minus size={16} />
-                ) : (
-                  <PlusIcon size={16} />
-                )}
-              </div>
-
-              {isMaxViewCountExpanded && (
-                <div>
-                  <WriteInput
-                    id="maxViewCount"
-                    type="number"
-                    placeholder="인원 수를 입력하세요"
-                    value={maxViewCount}
-                    onChange={(e) => setMaxViewCount(e.target.value)}
-                  />
+          <WriteDiv
+            title={
+              <div className="w-full">
+                <div
+                  className="flex items-center justify-between w-full cursor-pointer"
+                  onClick={() => {
+                    setIsMaxViewCountExpanded((prev) => !prev);
+                    if (isMaxViewCountExpanded) {
+                      setMaxViewCount("");
+                    }
+                  }}
+                >
+                  <span>선착순 인원</span>
+                  {isMaxViewCountExpanded ? (
+                    <Minus size={16} />
+                  ) : (
+                    <PlusIcon size={16} />
+                  )}
                 </div>
-              )}
-            </div>
+                <p className="text-xs text-text-3 mt-1">
+                  이 편지를 열어볼 수 있는 최대 인원수를 설정해 보세요
+                </p>
+              </div>
+            }
+          >
+            {isMaxViewCountExpanded ? (
+              <WriteInput
+                id="maxViewCount"
+                type="number"
+                placeholder="인원 수를 입력하세요"
+                value={maxViewCount}
+                onChange={(e) => setMaxViewCount(e.target.value)}
+              />
+            ) : null}
           </WriteDiv>
         )}
 

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -9,6 +9,8 @@ import {
   PaintBucket,
   Send,
   Check,
+  PlusIcon,
+  Minus,
 } from "lucide-react";
 import {
   CAPTURE_ENVELOPE_PALETTE,
@@ -127,6 +129,8 @@ export default function WriteForm({
     lat: undefined,
     lng: undefined,
   });
+  const [isMaxViewCountExpanded, setIsMaxViewCountExpanded] = useState(false);
+  const [maxViewCount, setMaxViewCount] = useState("");
 
   /* 편지 내용 글자 수 제한 길이 */
   const MAX_CONTENT_LENGTH = 3000;
@@ -352,6 +356,19 @@ export default function WriteForm({
       return;
     }
 
+    // 공개 캡슐 선착순 인원 검증
+    if (visibility === "PUBLIC" && isMaxViewCountExpanded) {
+      if (!maxViewCount || maxViewCount.trim() === "") {
+        toast.error("선착순 인원을 입력해 주세요.");
+        return;
+      }
+      const maxViewCountNum = parseInt(maxViewCount, 10);
+      if (maxViewCountNum < 1) {
+        toast.error("선착순 인원은 1 이상이어야 합니다.");
+        return;
+      }
+    }
+
     const envelopeSelected = envelopeThemes[selectedEnvelope];
     const paperSelected = paperThemes[selectedPaper];
 
@@ -389,6 +406,10 @@ export default function WriteForm({
       capsulePackingColor: envelopeSelected?.name ?? "",
       packingColor: envelopeSelected?.name ?? "",
       contentColor: paperSelected?.name ?? "",
+      maxViewCount:
+        visibility === "PUBLIC" && isMaxViewCountExpanded
+          ? parseInt(maxViewCount, 10) || 0
+          : null,
     });
 
     try {
@@ -733,6 +754,41 @@ export default function WriteForm({
                     placeholder="비밀번호를 입력하세요."
                   />
                 </WriteDiv>
+              )}
+            </div>
+          </WriteDiv>
+        )}
+
+        {visibility === "PUBLIC" && (
+          <WriteDiv title="선착순 인원">
+            <div className="flex flex-col gap-2">
+              <div
+                className="flex items-center justify-between cursor-pointer"
+                onClick={() => {
+                  setIsMaxViewCountExpanded((prev) => !prev);
+                  if (isMaxViewCountExpanded) {
+                    setMaxViewCount("");
+                  }
+                }}
+              >
+                <span className="text-sm">선착순 인원</span>
+                {isMaxViewCountExpanded ? (
+                  <Minus size={16} />
+                ) : (
+                  <PlusIcon size={16} />
+                )}
+              </div>
+
+              {isMaxViewCountExpanded && (
+                <div>
+                  <WriteInput
+                    id="maxViewCount"
+                    type="number"
+                    placeholder="인원 수를 입력하세요"
+                    value={maxViewCount}
+                    onChange={(e) => setMaxViewCount(e.target.value)}
+                  />
+                </div>
               )}
             </div>
           </WriteDiv>

--- a/src/lib/api/capsule/capsule.ts
+++ b/src/lib/api/capsule/capsule.ts
@@ -22,6 +22,7 @@ type BuildCommonArgs = {
   capsulePackingColor?: string;
   packingColor?: string;
   contentColor?: string;
+  maxViewCount?: number | null;
 };
 
 /**
@@ -192,6 +193,7 @@ export function buildPublicPayload(
     capsulePackingColor = "",
     packingColor = "",
     contentColor = "",
+    maxViewCount = null,
   } = args;
 
   const unlockAt =
@@ -248,7 +250,7 @@ export function buildPublicPayload(
       effectiveUnlockType === "TIME_AND_LOCATION"
         ? locationForm.viewingRadius
         : 0,
-    maxViewCount: 0,
+    maxViewCount: maxViewCount ?? null,
     attachmentIds: [], // 첨부 파일은 추후 구현
   };
 }

--- a/src/lib/utils/errorHandler.ts
+++ b/src/lib/utils/errorHandler.ts
@@ -1,0 +1,53 @@
+import { ApiError } from "@/lib/api/fetchClient";
+
+/**
+ * 에러 코드별 사용자 친화적 메시지 매핑
+ */
+export const ERROR_MESSAGES: Record<
+  string,
+  { title: string; description: string; showRetry?: boolean }
+> = {
+  FCM001: {
+    title: "선착순 마감되었습니다",
+    description: "이 편지는 선착순 인원이 마감되어 더 이상 열람할 수 없습니다.",
+    showRetry: false,
+  },
+  // 아래로 다른 에러 코드 추가
+};
+
+/**
+ * 에러 객체에서 에러 코드 추출
+ */
+export function getErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object") {
+    if (error instanceof ApiError) {
+      return error.code;
+    }
+    if ("code" in error) {
+      return String(error.code);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * 에러 코드에 해당하는 메시지 반환
+ */
+export function getErrorMessage(error: unknown): {
+  title: string;
+  description: string;
+  showRetry?: boolean;
+} | null {
+  const code = getErrorCode(error);
+  if (code && ERROR_MESSAGES[code]) {
+    return ERROR_MESSAGES[code];
+  }
+  return null;
+}
+
+/**
+ * 에러가 특정 에러 코드인지 확인
+ */
+export function isErrorCode(error: unknown, code: string): boolean {
+  return getErrorCode(error) === code;
+}

--- a/src/type/capsule/createCapsule.d.ts
+++ b/src/type/capsule/createCapsule.d.ts
@@ -63,7 +63,7 @@ interface CreatePublicCapsuleRequest {
   locationLat: number;
   locationLng: number;
   locationRadiusM: number;
-  maxViewCount: number;
+  maxViewCount: number | null;
   attachmentIds?: number[]; // 첨부 파일 ID 목록
 }
 


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

공개 캡슐 생성 시 선착순 인원 제한 기능을 추가하고, 선착순 마감 에러 처리를 개선했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #102 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 공개 캡슐 생성 폼에 선착순 인원 입력 필드 추가
  - `+`/`-` 버튼으로 펼치기/접기 기능 구현
  - 접힌 상태: `null` 전송, 펼쳐진 상태: 입력값 전송
  - 입력값 검증 (숫자만 허용, 1 이상)
- [x] 에러 처리 로직을 공통 유틸리티로 분리 (`src/lib/utils/errorHandler.ts`)
  - 에러 코드별 메시지 매핑
  - 재사용 가능한 에러 처리 함수 구현
- [x] 선착순 마감 에러 (`FCM001`) 처리 추가
  - 선착순 마감 시 관련 메시지 표시
  - 재시도 버튼 숨김 처리 `showRetry`

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="946" height="161" alt="image" src="https://github.com/user-attachments/assets/7909ac3d-88d2-4082-84a9-3e36a3527247" />
<img width="956" height="231" alt="image" src="https://github.com/user-attachments/assets/762bb3ec-3bc2-4e50-8314-0346f2efae40" />
<img width="393" height="105" alt="image" src="https://github.com/user-attachments/assets/464c8e55-6012-41b3-a3ed-a6f1d81e3b5f" />
<img width="404" height="94" alt="image" src="https://github.com/user-attachments/assets/1c353c2a-b1fe-4722-958e-f2a619cb29f4" />

<img width="685" height="343" alt="image" src="https://github.com/user-attachments/assets/da941730-b0fb-4c16-b62c-32f18b13e35d" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

- 공개 캡슐 생성 시 선착순 인원 입력 필드가 추가되었습니다.
- 선착순 마감 에러 발생 시 일반 서버 오류 대신 전용 메시지가 표시됩니다. (errorHandler.ts)

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- `errorHandler.ts`의 에러 코드 매핑 로직 확인 부탁드립니다. 다른 에러 코드도 매핑해서 사용할 수 있게 했습니다!
- 선착순 검증 관련 로직은 백엔드에서 처리중입니다.

