### PR TITLE
fix(QA): QA 진행 하면서 수정

### DIFF
--- a/src/app/(auth)/auth/profile/page.tsx
+++ b/src/app/(auth)/auth/profile/page.tsx
@@ -242,7 +242,7 @@ export default function AuthProfilePage() {
 
         <button
           type="button"
-          className="w-full text-center text-xs text-text-3 underline"
+          className="cursor-pointer w-full text-center text-xs text-text-3 underline"
           onClick={() => router.replace("/dashboard")}
         >
           나중에 할래요

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Input from "@/components/common/Input";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Button from "../common/Button";
 import { useRouter, useSearchParams } from "next/navigation";
 import { authApiClient } from "@/lib/api/auth/auth.client";
+import { useMe } from "@/lib/hooks/useMe";
 
 function getErrorMessage(err: unknown) {
   if (err instanceof Error) return err.message;
@@ -31,6 +32,20 @@ export default function LoginForm() {
   const [pw, setPw] = useState("");
   const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState(false);
+
+  const { data: me, isLoading: meLoading } = useMe();
+
+  useEffect(() => {
+    if (meLoading) return;
+    if (!me) return;
+
+    const isAdmin = me.role === "ADMIN";
+    const fallbackTarget = isAdmin ? "/admin/dashboard/users" : "/dashboard";
+    const target = returnUrl ?? fallbackTarget;
+
+    router.replace(target);
+    router.refresh();
+  }, [me, meLoading, returnUrl, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -397,9 +397,8 @@ export default function LetterDetailModal({
   // 저장 버튼 핸들러 (공개 편지 저장하기)
   const handleSave = async () => {
     try {
-      const me = await authApiClient.me();
-      console.log("me:", me);
-      if (!me) throw Object.assign(new Error("NO_ME"), { status: 401 });
+      const loggedIn = await authApiClient.isLoggedIn();
+      if (!loggedIn) throw Object.assign(new Error("NO_ME"), { status: 401 });
 
       const unlockAt = new Date().toISOString();
       saveMutation.mutate({ capsuleId, isSendSelf: 0, unlockAt });
@@ -415,6 +414,7 @@ export default function LetterDetailModal({
       }
 
       console.error("save error:", err);
+      toast.error("저장 중 오류가 발생했습니다.");
     }
   };
 

--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -18,6 +18,7 @@ import {
   Reply,
   Trash2,
   X,
+  Download,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -820,24 +821,25 @@ export default function LetterDetailModal({
                           <DropdownMenuItem
                             onClick={() => backupMutation.mutate(capsuleId)}
                           >
-                            <PencilLine className="text-primary" />
+                            <Download className="text-primary" />
                             {backupMutation.isPending
                               ? "백업 중..."
                               : "백업하기"}
                           </DropdownMenuItem>
                         )}
-                        {isSender && (
-                          <DropdownMenuItem
-                            onClick={() => {
-                              router.push(
-                                `/capsules/edit?capsuleId=${capsuleId}`
-                              );
-                            }}
-                          >
-                            <PencilLine className="text-primary" />
-                            수정하기
-                          </DropdownMenuItem>
-                        )}
+                        {isSender ||
+                          (capsule.viewStatus && (
+                            <DropdownMenuItem
+                              onClick={() => {
+                                router.push(
+                                  `/capsules/edit?capsuleId=${capsuleId}`
+                                );
+                              }}
+                            >
+                              <PencilLine className="text-primary" />
+                              수정하기
+                            </DropdownMenuItem>
+                          ))}
                         {(isSender || isReceiver) && (
                           <DropdownMenuItem
                             variant="destructive"

--- a/src/components/capsule/detail/LetterDetailView.tsx
+++ b/src/components/capsule/detail/LetterDetailView.tsx
@@ -9,7 +9,6 @@ import LetterLockedView from "./LetterLockedView";
 import { guestCapsuleApi } from "@/lib/api/capsule/guestCapsule";
 import { useRouter } from "next/navigation";
 import { CircleAlert } from "lucide-react";
-import { getErrorMessage } from "@/lib/utils/errorHandler";
 
 type LatLng = { lat: number; lng: number };
 
@@ -222,43 +221,66 @@ export default function LetterDetailView({
     );
   }
 
-  // 에러 메시지 가져오기
-  const errorMessage = getErrorMessage(error);
-
-  // 네트워크/서버 레벨 에러 (응답 자체가 없음)
-  if (isError || !data) {
+  // 인증 권한이 없을 때
+  if (error?.message === "인증이 필요합니다.") {
     return (
-      <div className="w-full min-h-full flex items-center justify-center p-8">
+      <div className="w-full flex items-center justify-center p-8">
         <div className="w-full max-w-md rounded-2xl border border-outline bg-white p-6 text-center space-y-4">
-          <div className="text-lg font-medium">
-            {errorMessage?.title ?? "서버 오류가 발생했어요"}
-          </div>
+          <div className="text-lg font-medium">권한이 없습니다.</div>
           <p className="text-sm text-text-2 whitespace-pre-line">
-            {errorMessage?.description ??
-              "잠시 후 다시 시도해 주세요.\n문제가 계속되면 네트워크 상태를 확인해 주세요."}
+            이 편지는 인증된 사용자에게만 공개됩니다.
+            {"\n"}
+            로그인하거나 권한을 확인한 뒤 다시 시도해 주세요.
           </p>
 
           <div className="flex gap-2 justify-center pt-2">
             <button
               type="button"
               onClick={handleBack}
-              className={`cursor-pointer px-4 py-2 rounded-lg ${
-                errorMessage?.showRetry === false
-                  ? "bg-primary text-white hover:opacity-90"
-                  : "border border-outline text-text hover:bg-button-hover"
-              }`}
+              className="cursor-pointer px-4 py-2 rounded-lg border border-outline text-text hover:bg-button-hover"
             >
               뒤로 가기
             </button>
-            {errorMessage?.showRetry !== false && (
-              <button
-                type="button"
-                onClick={() => refetch()}
-                className="cursor-pointer px-4 py-2 rounded-lg bg-primary text-white hover:opacity-90"
-              >
-                다시 시도
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="cursor-pointer px-4 py-2 rounded-lg bg-primary text-white hover:opacity-90"
+            >
+              다시 시도
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 네트워크/서버 레벨 에러 (응답 자체가 없음)
+  if (isError || !data) {
+    return (
+      <div className="w-full min-h-full flex items-center justify-center p-8">
+        <div className="w-full max-w-md rounded-2xl border border-outline bg-white p-6 text-center space-y-4">
+          <div className="text-lg font-medium">서버 오류가 발생했어요</div>
+          <p className="text-sm text-text-2 whitespace-pre-line">
+            잠시 후 다시 시도해 주세요.
+            {"\n"}
+            문제가 계속되면 네트워크 상태를 확인해 주세요.
+          </p>
+
+          <div className="flex gap-2 justify-center pt-2">
+            <button
+              type="button"
+              onClick={handleBack}
+              className="cursor-pointer px-4 py-2 rounded-lg border border-outline text-text hover:bg-button-hover"
+            >
+              뒤로 가기
+            </button>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="cursor-pointer px-4 py-2 rounded-lg bg-primary text-white hover:opacity-90"
+            >
+              다시 시도
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/capsule/detail/LetterDetailView.tsx
+++ b/src/components/capsule/detail/LetterDetailView.tsx
@@ -228,7 +228,7 @@ export default function LetterDetailView({
   // 네트워크/서버 레벨 에러 (응답 자체가 없음)
   if (isError || !data) {
     return (
-      <div className="w-full h-full flex items-center justify-center p-8">
+      <div className="w-full min-h-full flex items-center justify-center p-8">
         <div className="w-full max-w-md rounded-2xl border border-outline bg-white p-6 text-center space-y-4">
           <div className="text-lg font-medium">
             {errorMessage?.title ?? "서버 오류가 발생했어요"}

--- a/src/components/capsule/detail/LetterLockedView.tsx
+++ b/src/components/capsule/detail/LetterLockedView.tsx
@@ -319,7 +319,7 @@ export default function LetterLockedView({
                 onClick={() => router.push("/auth/login")}
                 type="button"
               >
-                로그인하고 저장하기
+                대시보드로 이동
               </button>
             </div>
           )}

--- a/src/components/capsule/detail/LetterPasswordModal.tsx
+++ b/src/components/capsule/detail/LetterPasswordModal.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import Button from "@/components/common/Button";
 import Logo from "@/components/common/Logo";
-import ForbiddenPage from "./ForbiddenPage";
 
 export default function LetterUnlockModal({
   onSuccess,
@@ -28,8 +27,6 @@ export default function LetterUnlockModal({
     // 비밀번호만 전달 (read API는 LetterDetailView에서 호출)
     onSuccess(password);
   };
-
-  if (error === "이 캡슐의 수신자가 아닙니다.") return <ForbiddenPage />;
 
   return (
     <section className="w-full max-w-120 rounded-3xl border border-outline bg-white shadow-xl p-10">

--- a/src/components/capsule/guest/CapsuleGate.tsx
+++ b/src/components/capsule/guest/CapsuleGate.tsx
@@ -32,8 +32,8 @@ export default function CapsuleGate({ uuId }: { uuId: string }) {
 
   const { capsuleId, existedPassword, isProtected } = payload;
 
-  // 비밀번호 있는 캡슐이면: 비밀번호 입력 → 성공 시 상세로
-  if (existedPassword && !password) {
+  // 비밀번호가 존재하고 isProtected가 0인 캡슐이면: 비밀번호 입력 → 성공 시 상세로
+  if (existedPassword && !isProtected && !password) {
     return (
       <div className="w-full min-h-screen flex items-center justify-center">
         <LetterPasswordModal

--- a/src/components/capsule/guest/CapsuleGate.tsx
+++ b/src/components/capsule/guest/CapsuleGate.tsx
@@ -45,10 +45,12 @@ export default function CapsuleGate({ uuId }: { uuId: string }) {
   }
 
   return (
-    <LetterDetailView
-      capsuleId={capsuleId}
-      isProtected={isProtected}
-      password={password}
-    />
+    <div className="w-full min-h-screen flex items-center justify-center">
+      <LetterDetailView
+        capsuleId={capsuleId}
+        isProtected={isProtected}
+        password={password}
+      />
+    </div>
   );
 }

--- a/src/components/capsule/new/WritePage.tsx
+++ b/src/components/capsule/new/WritePage.tsx
@@ -48,7 +48,7 @@ export default function WritePage() {
         <button
           type="button"
           onClick={() => setIsPreviewOpen(true)}
-          className="w-full flex items-center justify-center gap-2 rounded-xl bg-primary-2 text-white py-3"
+          className="cursor-pointer w-full flex items-center justify-center gap-2 rounded-xl bg-primary-2 text-white py-3"
         >
           <Eye size={18} />
           미리보기
@@ -71,7 +71,7 @@ export default function WritePage() {
               <button
                 type="button"
                 onClick={() => setIsPreviewOpen(false)}
-                className="p-2 rounded-lg hover:bg-outline/30"
+                className="cursor-pointer p-2 rounded-lg hover:bg-outline/30"
               >
                 <X size={18} />
               </button>

--- a/src/components/capsule/new/left/WriteForm.tsx
+++ b/src/components/capsule/new/left/WriteForm.tsx
@@ -564,7 +564,7 @@ export default function WriteForm({
                     key={`${item.name}-${idx}`}
                     type="button"
                     onClick={() => setSelectedEnvelope(idx)}
-                    className={`relative aspect-square rounded-2xl border-2 transition ${
+                    className={`cursor-pointer relative aspect-square rounded-2xl border-2 transition ${
                       selectedEnvelope === idx
                         ? "border-primary bg-primary/10"
                         : "border-outline"
@@ -589,7 +589,7 @@ export default function WriteForm({
                     key={`${item.name}-${idx}`}
                     type="button"
                     onClick={() => setSelectedPaper(idx)}
-                    className={`relative aspect-square rounded-2xl border-2 transition ${
+                    className={`cursor-pointer relative aspect-square rounded-2xl border-2 transition ${
                       selectedPaper === idx
                         ? "border-primary bg-primary/10"
                         : "border-outline"
@@ -614,7 +614,7 @@ export default function WriteForm({
         <WriteDiv title="보내는 사람">
           <div className="space-y-2">
             <div className="flex items-center justify-end gap-3 text-sm text-text-1 -mt-8 mb-2">
-              <label className="flex items-center gap-1 cursor-pointer">
+              <label className="flex items-center gap-1">
                 <input
                   type="checkbox"
                   checked={senderMode === "name"}
@@ -622,7 +622,7 @@ export default function WriteForm({
                 />
                 <span>이름</span>
               </label>
-              <label className="flex items-center gap-1 cursor-pointer">
+              <label className="flex items-center gap-1">
                 <input
                   type="checkbox"
                   checked={senderMode === "nickname"}

--- a/src/components/capsule/new/left/unlockOpt/KakaoLocation.tsx
+++ b/src/components/capsule/new/left/unlockOpt/KakaoLocation.tsx
@@ -356,7 +356,7 @@ const KakaoLocation = forwardRef<KakaoLocationHandle, KakaoLocationProps>(
             onClick={moveToMyLocation}
             disabled={!ready || isLocating}
             aria-label="내 위치로 이동"
-            className="bg-white absolute bottom-3 right-3 p-3 rounded-xl z-10 shadow-lg text-primary disabled:opacity-50"
+            className="cursor-pointer bg-white absolute bottom-3 right-3 p-3 rounded-xl z-10 shadow-lg text-primary disabled:opacity-50"
           >
             <LocateFixed size={22} />
           </button>
@@ -379,7 +379,7 @@ const KakaoLocation = forwardRef<KakaoLocationHandle, KakaoLocationProps>(
                 <button
                   key={item.id}
                   type="button"
-                  className="w-full text-left px-3 py-2 hover:bg-sub-2 border-b border-outline last:border-b-0"
+                  className="cursor-pointer w-full text-left px-3 py-2 hover:bg-sub-2 border-b border-outline last:border-b-0"
                   onClick={() => {
                     // x/y(문자열)을 lng/lat(숫자)로 변환
 

--- a/src/components/capsule/report/ReportModal.tsx
+++ b/src/components/capsule/report/ReportModal.tsx
@@ -135,10 +135,10 @@ export default function ReportModal({
             </div>
 
             <button
+              type="button"
               onClick={handleClose}
               className="cursor-pointer p-2 rounded-lg hover:bg-white/10 transition"
               aria-label="닫기"
-              type="button"
             >
               <X size={20} />
             </button>

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -29,7 +29,7 @@ export default function Pagination({
 
       <button
         type="button"
-        className="px-3 py-1 rounded-lg border border-outline disabled:opacity-40"
+        className="cursor-pointer px-3 py-1 rounded-lg border border-outline disabled:opacity-40"
         onClick={() => onPageChange(Math.max(0, page - 1))}
         disabled={isFirst}
       >
@@ -38,7 +38,7 @@ export default function Pagination({
 
       <button
         type="button"
-        className="px-3 py-1 rounded-lg border border-outline disabled:opacity-40"
+        className="cursor-pointer px-3 py-1 rounded-lg border border-outline disabled:opacity-40"
         onClick={() => onPageChange(Math.min(totalPages - 1, page + 1))}
         disabled={isLast}
       >

--- a/src/components/dashboard/admin/contents/body/AdminBody.tsx
+++ b/src/components/dashboard/admin/contents/body/AdminBody.tsx
@@ -69,29 +69,28 @@ export default function AdminBody({
   return (
     <div className="space-y-4 md:space-y-6 lg:space-y-8">
       {/* 검색 */}
-      <div className="relative w-full">
-        <Search
-          size={20}
-          className="absolute left-4 top-1/2 -translate-y-1/2 text-text-4"
-        />
-        <input
-          type="text"
-          placeholder={searchPlaceholder}
-          className="w-full text-xs md:text-base p-3 lg:p-4 pl-12 bg-white/80 border border-outline rounded-xl outline-none focus:border-primary-2"
-          value={keywordInput}
-          onChange={(e) => setKeywordInput(e.target.value)}
-          onBlur={commitKeyword} // 포커스 빠질 때 검색 적용
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              commitKeyword(); // Enter로 검색 적용
-            }
-            if (e.key === "Escape") {
-              e.preventDefault();
-              cancelKeyword(); // ESC로 입력 취소
-            }
-          }}
-        />
+      <div className="w-full">
+        <div className="flex items-center gap-3 w-full bg-white/80 border border-outline rounded-xl focus-within:border-primary-2 px-4 py-3 lg:py-4">
+          <Search size={20} className="text-text-4 shrink-0" />
+          <input
+            type="text"
+            placeholder={searchPlaceholder}
+            className="w-full bg-transparent outline-none text-xs md:text-base"
+            value={keywordInput}
+            onChange={(e) => setKeywordInput(e.target.value)}
+            onBlur={commitKeyword} // 포커스 빠질 때 검색 적용
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commitKeyword(); // Enter로 검색 적용
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                cancelKeyword(); // ESC로 입력 취소
+              }
+            }}
+          />
+        </div>
       </div>
 
       {/* 메뉴 탭 */}

--- a/src/components/dashboard/admin/sidebar/AdminSidebar.tsx
+++ b/src/components/dashboard/admin/sidebar/AdminSidebar.tsx
@@ -96,7 +96,7 @@ export default function AdminSidebar({
                 <button
                   type="button"
                   onClick={onMobileClose}
-                  className="p-2 rounded-lg hover:bg-button-hover"
+                  className="cursor-pointer p-2 rounded-lg hover:bg-button-hover"
                   aria-label="메뉴 닫기"
                 >
                   <X size={20} />

--- a/src/components/dashboard/contents/mailbox/MailboxPage.tsx
+++ b/src/components/dashboard/contents/mailbox/MailboxPage.tsx
@@ -183,7 +183,7 @@ export default function MailboxPage({
             </div>
           </div>
 
-          <div className="flex flex-col sm:grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 flex-wrap gap-8">
+          <div className="flex flex-col sm:grid sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 flex-wrap gap-8">
             {!list.length ? (
               <p className="text-text-3">
                 {isBookmark ? "북마크한 편지가 없습니다" : "편지가 없습니다"}

--- a/src/components/dashboard/map/FilterArea.tsx
+++ b/src/components/dashboard/map/FilterArea.tsx
@@ -37,7 +37,7 @@ export default function FilterArea({
               key={opt.value}
               type="button"
               onClick={() => onRadiusChange(opt.value)}
-              className={`px-3 py-2 rounded-lg text-sm border transition
+              className={`cursor-pointer px-3 py-2 rounded-lg text-sm border transition
                 ${
                   radius === opt.value
                     ? "border-primary bg-primary/5 text-primary"
@@ -101,14 +101,14 @@ export default function FilterArea({
         <button
           type="button"
           onClick={onReset}
-          className="w-full py-2 rounded-lg border border-outline text-sm hover:bg-sub transition"
+          className="cursor-pointer w-full py-2 rounded-lg border border-outline text-sm hover:bg-sub transition"
         >
           초기화
         </button>
         <button
           type="button"
           onClick={onClose}
-          className="w-full py-2 rounded-lg bg-primary text-white text-sm hover:opacity-90 transition"
+          className="cursor-pointer w-full py-2 rounded-lg bg-primary text-white text-sm hover:opacity-90 transition"
         >
           적용
         </button>

--- a/src/components/dashboard/map/FilterRow.tsx
+++ b/src/components/dashboard/map/FilterRow.tsx
@@ -13,7 +13,7 @@ export default function FilterRow({
     <button
       type="button"
       onClick={onClick}
-      className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition
+      className={`cursor-pointer w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition
         ${active ? "bg-primary/5 text-primary" : "hover:bg-sub text-text-2"}`}
     >
       <span>{label}</span>

--- a/src/components/dashboard/map/MapContents.tsx
+++ b/src/components/dashboard/map/MapContents.tsx
@@ -217,7 +217,7 @@ export default function MapContents() {
           {/* 사용자 위치 불러오기 버튼 */}
           <button
             type="button"
-            className="bg-white absolute bottom-4 right-4 p-3 rounded-xl z-10 shadow-lg text-primary"
+            className="cursor-pointer bg-white absolute bottom-4 right-4 p-3 rounded-xl z-10 shadow-lg text-primary"
             onClick={MoveMyLocation}
           >
             <LocateFixed size={24} />
@@ -226,7 +226,7 @@ export default function MapContents() {
           {/* 모바일: 리스트 열기 버튼 */}
           <button
             type="button"
-            className="lg:hidden absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-3 rounded-xl z-10 shadow-lg text-sm bg-primary-2 text-white"
+            className="cursor-pointer lg:hidden absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-3 rounded-xl z-10 shadow-lg text-sm bg-primary-2 text-white"
             onClick={() => setIsListOpen(true)}
           >
             주변 편지 보기 (
@@ -245,7 +245,7 @@ export default function MapContents() {
               <button
                 type="button"
                 onClick={() => setIsFilterOpen((v) => !v)}
-                className="p-2 rounded-lg hover:bg-sub transition"
+                className="cursor-pointer p-2 rounded-lg hover:bg-sub transition"
                 aria-haspopup="menu"
                 aria-expanded={isFilterOpen}
               >
@@ -320,7 +320,7 @@ export default function MapContents() {
                     setIsListOpen(true);
                     setIsFilterOpen((v) => !v);
                   }}
-                  className="p-2 rounded-lg hover:bg-sub transition"
+                  className="cursor-pointer p-2 rounded-lg hover:bg-sub transition"
                   aria-haspopup="menu"
                   aria-expanded={isFilterOpen}
                 >
@@ -330,7 +330,7 @@ export default function MapContents() {
                 <button
                   type="button"
                   onClick={() => setIsListOpen(false)}
-                  className="p-2 rounded-lg hover:bg-sub transition"
+                  className="cursor-pointer p-2 rounded-lg hover:bg-sub transition"
                   aria-label="닫기"
                 >
                   ✕

--- a/src/components/dashboard/map/MapList.tsx
+++ b/src/components/dashboard/map/MapList.tsx
@@ -68,7 +68,7 @@ export default function MapList({ listData, onClick, focus }: MapListProps) {
             <button
               key={d.capsuleId}
               type="button"
-              className="group w-full text-left rounded-xl hover:bg-button-hover focus:bg-primary-2"
+              className="group cursor-pointer w-full text-left rounded-xl hover:bg-button-hover focus:bg-primary-2"
               onClick={() =>
                 onClick(d.capsuleId, d.capsuleLatitude, d.capsuleLongitude)
               }

--- a/src/components/dashboard/sidebar/Profile.tsx
+++ b/src/components/dashboard/sidebar/Profile.tsx
@@ -48,7 +48,11 @@ export default function Profile({
   const firstChar = isAdmin ? "A" : me?.name?.[0] ?? "";
 
   return (
-    <button type="button" onClick={onClick} className="w-full text-left">
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${isAdmin ?? "cursor-pointer"} w-full text-left`}
+    >
       <DivBox className="p-4 lg:p-6 border-2">
         <div className="flex items-center gap-3">
           <div className="flex-none bg-text w-14 h-14 rounded-full">

--- a/src/components/dashboard/sidebar/Sidebar.tsx
+++ b/src/components/dashboard/sidebar/Sidebar.tsx
@@ -105,7 +105,7 @@ export default function Sidebar({
                 <button
                   type="button"
                   onClick={onMobileClose}
-                  className="p-2 rounded-lg hover:bg-button-hover"
+                  className="cursor-pointer p-2 rounded-lg hover:bg-button-hover"
                   aria-label="메뉴 닫기"
                 >
                   <X size={20} />

--- a/src/components/dashboard/sidebar/profile/ProfileModal.tsx
+++ b/src/components/dashboard/sidebar/profile/ProfileModal.tsx
@@ -293,7 +293,7 @@ export default function ProfileModal({
 
                 <button
                   type="button"
-                  className="w-full text-center text-xs text-text-3 underline"
+                  className="cursor-pointer w-full text-center text-xs text-text-3 underline"
                 >
                   비밀번호를 잊으셨나요?
                 </button>

--- a/src/components/dashboard/storyTrack/all/AllTrackPage.tsx
+++ b/src/components/dashboard/storyTrack/all/AllTrackPage.tsx
@@ -195,7 +195,7 @@ export default function AllTrackPage() {
             {error instanceof Error ? error.message : String(error)}
           </pre>
           <button
-            className="mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
+            className="cursor-pointer mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
             onClick={() => refetch()}
             type="button"
           >

--- a/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
+++ b/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
@@ -1,28 +1,21 @@
 "use client";
 
-import Button from "@/components/common/Button";
-import {
-  ListOrdered,
-  MapPin,
-  Play,
-  Shuffle,
-  TrendingUp,
-  Users,
-} from "lucide-react";
+import { ListOrdered, MapPin, Shuffle, TrendingUp, Users } from "lucide-react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
-  const router = useRouter();
-
-  // 추가: 진행률 계산
+  // 진행률 계산
   const total = track.totalSteps ?? 0;
   const done = track.completedSteps ?? 0;
   const percent = total > 0 ? Math.round((done / total) * 100) : 0;
 
   return (
-    <>
-      <div className="relative border border-outline rounded-xl">
+    <Link
+      href={`/dashboard/storyTrack/${track.storytrackId}`}
+      className="block border border-outline rounded-xl hover:shadow-md transition"
+    >
+      <div className="relative">
         {/* Top */}
         <Image
           src="https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"
@@ -31,16 +24,18 @@ export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
           height={200}
           className="w-full h-40 object-cover rounded-t-xl"
         />
-        {/* 달성도 */}
+
+        {/* 달성도 배지 */}
         <div className="absolute top-3 right-3 flex items-center gap-1 px-3 py-2 rounded-lg text-white bg-primary-3 text-sm">
           <TrendingUp size={18} />
           <span>{percent}% 완료</span>
         </div>
+
         {/* Bottom */}
         <div className="p-6 space-y-4">
           {/* 제목과 소개 */}
           <div className="space-y-1">
-            <p>{track.title}</p>
+            <p className="font-medium">{track.title}</p>
             <p className="text-sm text-text-3 line-clamp-2 break-keep">
               {track.description}
             </p>
@@ -49,7 +44,6 @@ export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
           {/* 작성자 프로필 */}
           <div className="flex items-center gap-1.5">
             <div className="flex-none w-6 h-6 rounded-full bg-black text-white text-xs flex items-center justify-center">
-              {/* 그 사람의 프로필 */}
               {track.creatorNickname?.[0] ?? "?"}
             </div>
             <p className="text-xs text-text-2">{track.creatorNickname}</p>
@@ -63,13 +57,11 @@ export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
                 {done} / {total} 완료
               </span>
             </div>
-            <div>
-              <div className="relative w-full h-2 bg-button-hover rounded-full overflow-hidden">
-                <div
-                  className="absolute inset-0 bg-primary-2 rounded-full"
-                  style={{ width: `${percent}%` }}
-                ></div>
-              </div>
+            <div className="relative w-full h-2 bg-button-hover rounded-full overflow-hidden">
+              <div
+                className="absolute inset-y-0 left-0 bg-primary-2 rounded-full"
+                style={{ width: `${percent}%` }}
+              />
             </div>
           </div>
 
@@ -97,19 +89,8 @@ export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
               {track.totalMemberCount ?? 0}명
             </div>
           </div>
-
-          {/* 버튼 */}
-          {/* <Button
-            onClick={() =>
-              router.push(`/dashboard/storyTrack/${track.storytrackId}`)
-            }
-            className="md:font-normal gap-1 w-full py-3"
-          >
-            <Play size={20} />
-            계속하기
-          </Button> */}
         </div>
       </div>
-    </>
+    </Link>
   );
 }

--- a/src/components/dashboard/storyTrack/joined/JoinedTrackPage.tsx
+++ b/src/components/dashboard/storyTrack/joined/JoinedTrackPage.tsx
@@ -94,7 +94,7 @@ export default function JoinedTrackPage() {
             {error instanceof Error ? error.message : String(error)}
           </pre>
           <button
-            className="mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
+            className="cursor-pointer mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
             onClick={() => refetch()}
             type="button"
           >

--- a/src/components/dashboard/storyTrack/mine/MineTrackPage.tsx
+++ b/src/components/dashboard/storyTrack/mine/MineTrackPage.tsx
@@ -92,7 +92,7 @@ export default function MineTrackPage() {
             {error instanceof Error ? error.message : String(error)}
           </pre>
           <button
-            className="mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
+            className="cursor-pointer mt-4 px-3 py-2 rounded-xl border border-outline text-text-2 hover:bg-white"
             onClick={() => refetch()}
             type="button"
           >

--- a/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
+++ b/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
@@ -196,7 +196,7 @@ export default function CreateStoryTrack() {
               <Button
                 type="button"
                 onClick={() => setStep((s) => (s === 2 ? 1 : s))}
-                className="md:font-normal py-2 px-8 bg-white border border-outline text-text"
+                className="md:font-normal py-2 px-8 bg-white border border-outline text-text hover:bg-button-hover"
               >
                 이전
               </Button>

--- a/src/components/dashboard/storyTrack/new/secondForm/PublicLetterPicker.tsx
+++ b/src/components/dashboard/storyTrack/new/secondForm/PublicLetterPicker.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+/* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
+import { Search } from "lucide-react";
 
 /**
  * CapsuleDashboardItem을 Letter 타입으로 변환
@@ -19,64 +23,116 @@ function toLetter(item: CapsuleDashboardItem): Letter {
 
 export default function PublicLetterPicker({
   onSelect,
+  selectedIds,
 }: {
   onSelect: (letter: Letter) => void;
+  selectedIds?: Set<string>;
 }) {
-  // 공개 캡슐 목록 조회
-  // 캡슐 100개 최대, 100개 이상이 필요하면 무한스크롤 구현 필요
+  const [q, setQ] = useState("");
+
   const { data, isLoading, isError } = useQuery({
     queryKey: ["storytrackCapsuleList"],
     queryFn: ({ signal }) =>
       storyTrackApi.getCapsuleList({ page: 0, size: 100 }, signal),
-    staleTime: 1000 * 30, // 30초간 캐시 유지: 이 시간 동안은 API 재호출 없이 캐시된 데이터 사용
+    staleTime: 1000 * 30,
   });
 
-  // 로딩 중
   if (isLoading) {
     return (
-      <div className="px-4 py-8 text-center text-text-3 text-sm">
+      <div className="px-5 py-10 text-center text-text-3 text-sm">
         공개 편지 목록을 불러오는 중...
       </div>
     );
   }
 
-  // 에러 발생
   if (isError) {
     return (
-      <div className="px-4 py-8 text-center text-text-3 text-sm">
+      <div className="px-5 py-10 text-center text-text-3 text-sm">
         공개 편지 목록을 불러오지 못했습니다.
       </div>
     );
   }
 
-  // 데이터 변환
   const letters: Letter[] = data?.data?.content?.map(toLetter) ?? [];
 
-  // 빈 목록
   if (letters.length === 0) {
     return (
-      <div className="px-4 py-8 text-center text-text-3 text-sm">
+      <div className="px-5 py-10 text-center text-text-3 text-sm">
         공개 편지가 없습니다.
       </div>
     );
   }
 
+  const filtered = useMemo(() => {
+    const keyword = q.trim().toLowerCase();
+    if (!keyword) return letters;
+    return letters.filter((l) => {
+      const t = (l.title ?? "").toLowerCase();
+      const p = (l.placeName ?? "").toLowerCase();
+      return t.includes(keyword) || p.includes(keyword);
+    });
+  }, [letters, q]);
+
   return (
-    <ul className="divide-y divide-outline">
-      {letters.map((l) => (
-        <li key={l.id}>
-          <button
-            type="button"
-            onClick={() => onSelect(l)}
-            className="w-full text-left px-4 py-3 hover:bg-button-hover"
-          >
-            <div className="text-sm text-text">{l.title}</div>
-            <div className="text-xs text-text-4">
-              {l.placeName ?? "위치 미지정"}
-            </div>
-          </button>
-        </li>
-      ))}
-    </ul>
+    <div className="p-4">
+      {/* 검색바 */}
+      <div className="sticky top-0 z-10 bg-white pb-3">
+        <div className="flex items-center gap-2 rounded-xl border border-outline bg-white px-3 py-2">
+          <Search size={16} className="text-text-4" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="제목/장소로 검색"
+            className="w-full bg-transparent outline-none text-sm text-text placeholder:text-text-4"
+          />
+        </div>
+        <div className="mt-2 text-xs text-text-4">총 {filtered.length}개</div>
+      </div>
+
+      {/* 리스트 */}
+      <ul className="space-y-2">
+        {filtered.map((l) => {
+          const already = selectedIds?.has(l.id) ?? false;
+
+          return (
+            <li key={l.id}>
+              <button
+                type="button"
+                disabled={already}
+                onClick={() => onSelect(l)}
+                className={[
+                  "w-full text-left rounded-xl border-2 border-outline bg-white px-4 py-3",
+                  "transition active:scale-[0.99]",
+                  already
+                    ? "border-primary border opacity-40 cursor-not-allowed"
+                    : "hover:bg-button-hover cursor-pointer",
+                ].join(" ")}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-text line-clamp-1">
+                      {l.title}
+                    </div>
+                    <div className="mt-1 text-xs text-text-4 line-clamp-1">
+                      {l.placeName ?? "위치 미지정"}
+                    </div>
+                  </div>
+
+                  {already ? (
+                    <span className="shrink-0 inline-flex items-center rounded-full border border-primary px-2 py-1 text-xs text-primary">
+                      추가됨
+                    </span>
+                  ) : (
+                    <span className="shrink-0 inline-flex items-center rounded-full border border-outline bg-white px-2 py-1 text-xs text-text-4">
+                      선택
+                    </span>
+                  )}
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }

--- a/src/components/dashboard/storyTrack/new/secondForm/SortableRouteItem.tsx
+++ b/src/components/dashboard/storyTrack/new/secondForm/SortableRouteItem.tsx
@@ -39,7 +39,7 @@ export default function SortableRouteItem({
       {/* Drag handle */}
       <button
         type="button"
-        className="p-1 rounded-md hover:bg-button-hover text-text-4"
+        className="cursor-grab p-1 rounded-md hover:bg-button-hover text-text-4"
         aria-label="드래그해서 순서 변경"
         {...attributes}
         {...listeners}
@@ -66,7 +66,7 @@ export default function SortableRouteItem({
       <button
         type="button"
         onClick={onRemove}
-        className="p-2 rounded-md hover:bg-button-hover text-text-4 hover:text-text"
+        className="cursor-pointer p-2 rounded-md hover:bg-button-hover text-text-4 hover:text-text"
         aria-label="삭제"
       >
         <Trash2 size={18} />

--- a/src/lib/api/auth/auth.client.ts
+++ b/src/lib/api/auth/auth.client.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { apiFetch } from "../fetchClient";
 
 export const authApiClient = {
@@ -12,6 +13,17 @@ export const authApiClient = {
 
   me: (signal?: AbortSignal) =>
     apiFetch<MemberMe>("/api/v1/members/me", { signal }),
+
+  isLoggedIn: async (signal?: AbortSignal) => {
+    try {
+      await apiFetch<MemberMe>("/api/v1/members/me", { signal });
+      return true;
+    } catch (e: any) {
+      const status = e?.status ?? e?.response?.status;
+      if (status === 401 || status === 403) return false;
+      throw e;
+    }
+  },
 
   logout: () => apiFetch<void>("/api/v1/auth/logout", { method: "POST" }),
 };


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요
QA 진행 하면서 수정한 내용
<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #

## 🛠️ 상세 작업 내용

1. 응답 없음 ui 세로 가운데 정렬
2. 관리자 페이지 검색 아이콘
3. 상대방 읽은 상태에 따라 수정 버튼 안보이게 수정
4. 로그인 페이지에서 쿠키가 있으면 자동 로그인
5. 저장하기 기능 오류 수정
=> /api/v1/members/me(회원정보) api에서 로그인 안 된 상태에서 401이 아니라 302 리다이렉트로 Google OAuth 주소로 보내버리고 있음
(백엔드에서 401 반환해주면 좋지만, 시간이 없기에 일단 프론트에서 fetch 파일에서 구글로 따라가지 않도록 막고, 302를 “로그인 필요”로 처리하도록 바꿈)

오류 코드
`b363d6b9-7ad2-49ea-a0fe-149241a28b06:1 Access to fetch at 'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&response_t…dgOI2dqWgCY%3D&redirect_uri=http://localhost:8080/login/oauth2/code/google' (redirected from 'http://localhost:8080/api/v1/members/me') from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

6. 공개편지 조회 시, “Dear.수신자이름” 처리 되도록 구현 및 빈 데이터일 경우 '당신'
7. 비회원 로직 수정
8. 권한이 없을 경우 ui 추가 수정
9. 스토리트랙 생성 시 공개편지 선택 부분 별개 모달로 변경 및 버튼 용도에 맞게 커서 효과 추가
10. type이 button일 경우, cursor-pointer css 추가
11. 참여 중인 트랙 리스트에서 카드 링크 연결

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
