### PR TITLE
[#130] refactor(storytrack-edit): 리액트 컴파일러 1.0v 적용 및 스토리트랙 수정 기능에서 useMemo 사용한 부분 제거

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,10 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  experimental: {
+    // @ts-expect-error - 실험적 단계라 아직 타입 정의에 포함되지 않음
+    reactCompiler: true,
+  },
 };
 
 export default nextConfig;

--- a/src/components/dashboard/storyTrack/edit/EditStoryTrack.tsx
+++ b/src/components/dashboard/storyTrack/edit/EditStoryTrack.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import Button from "@/components/common/Button";
 import { useRouter, useParams } from "next/navigation";
 import BackButton from "@/components/common/BackButton";
@@ -79,14 +79,11 @@ export default function EditStoryTrack() {
   }, [trackData]);
 
   // 변경사항이 있는지 확인
-  const hasChanges = useMemo(() => {
-    return (
-      originalRouteItems.length !== step1.routeItems.length ||
-      originalRouteItems.some(
-        (original, index) => original.id !== step1.routeItems[index]?.id
-      )
+  const hasChanges =
+    originalRouteItems.length !== step1.routeItems.length ||
+    originalRouteItems.some(
+      (original, index) => original.id !== step1.routeItems[index]?.id
     );
-  }, [originalRouteItems, step1.routeItems]);
 
   const handleCancel = () => {
     if (storytrackId) {


### PR DESCRIPTION
refactor(storytrack-edit): 리액트 컴파일러 1.0v 적용 및 스토리트랙 수정 기능에서 useMemo 사용한 부분 제거

<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

1.React 컴파일러 1.0v을 프로젝트에 적용
2.스토리트랙 수정 기능에서 useMemo을 제거하여 React 컴파일러가 자동으로 최적화하도록 변경했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #130 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] `babel-plugin-react-compiler@^1.0.0` 설치
- [x] `next.config.ts`에 `experimental.reactCompiler: true` 설정 추가
- [x] `EditStoryTrack.tsx`에서 `hasChanges` 계산의 `useMemo` 제거
- [x] `useMemo` import 제거 (더 이상 사용하지 않음)

## 🔧 기술적 세부사항

### React 컴파일러 설정
- **설치**: `babel-plugin-react-compiler@^1.0.0`를 devDependencies에 추가
- **Next.js 설정**: `next.config.ts`의 `experimental.reactCompiler: true` 옵션 활성화
- **타입 오류 처리**: `@ts-expect-error` 주석을 사용하여 타입 정의에 아직 포함되지 않은 실험적 기능의 타입 오류 처리

### useMemo 제거
- 변경 전: `hasChanges`를 `useMemo`로 메모이제이션하여 매 렌더링마다 재계산 방지
- 변경 후: `useMemo` 제거 후 React 컴파일러가 자동으로 메모이제이션 처리

### 변경된 파일
1. `package.json`: `babel-plugin-react-compiler` 추가
2. `next.config.ts`: React 컴파일러 설정 추가
3. `src/components/dashboard/storyTrack/edit/EditStoryTrack.tsx`: `useMemo` 제거

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

_N/A_

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

- React DevTools v5.0+에서 "Memo ✨" 배지로 컴파일러 최적화 여부 확인 가능합니다.
- `next.config.ts`의 `@ts-expect-error` 주석은 Next.js가 타입 정의를 업데이트할 때까지 유지 필요

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

- [x] React 컴파일러가 제대로 동작하는지 확인 (React DevTools에서 ✨ 마크 확인)
- [x] 리액트 컴파일러 설치 이후 npm install 안하신 분들 한번 씩 부탁드립니다.
- [x] experimental.reactCompiler: true 요부분 자꾸 타입 에러 나서 찾아보니 실험적 기능이라 타입정의에 없어서 그렇다고 알고 진행했습니다. 혹시 다르게 알고 계신 분 있으면 가르침을 주세요
