### PR TITLE
[#132] feat(storytrack-thumbnail): 스토리트랙 썸네일 업로드 Presigned URL 방식으로 구현

### DIFF
--- a/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
+++ b/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
@@ -18,7 +18,7 @@ type FormState = {
   title: string;
   description: string;
   order: TrackType;
-  thumbnailAttachmentId?: number;
+  thumbnailAttachmentId: number | undefined; // 필수 (초기값은 undefined)
 
   // step2
   routeLetterIds: string[];
@@ -78,6 +78,7 @@ export default function CreateStoryTrack() {
       setIsSubmitting(true);
 
       // FormState → CreateStorytrackRequest 변환
+      // canSubmitFromStep2와 canGoNextFromStep1 검증을 통과했으므로 thumbnailAttachmentId는 반드시 존재
       const payload: CreateStorytrackRequest = {
         title: form.title.trim(),
         description: form.description.trim(),
@@ -85,7 +86,7 @@ export default function CreateStoryTrack() {
         isPublic: 1, // 기본값: 공개
         price: 0, // 기본값: 무료
         capsuleList: form.routeLetterIds.map((id) => Number(id)), // string[] → number[]
-        attachmentId: form.thumbnailAttachmentId, // 썸네일 attachmentId
+        attachmentId: form.thumbnailAttachmentId!, // 썸네일 attachmentId (필수, 검증 완료)
       };
 
       // API 호출

--- a/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
+++ b/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
@@ -19,6 +19,7 @@ type FormState = {
   description: string;
   order: TrackType;
   thumbnailAttachmentId: number | undefined; // 필수 (초기값은 undefined)
+  thumbnailStatus?: "UPLOADING" | "PENDING" | "TEMP" | "DELETED" | "USED"; // 썸네일 상태
 
   // step2
   routeLetterIds: string[];
@@ -33,6 +34,7 @@ const initialState: FormState = {
   description: "",
   order: "SEQUENTIAL",
   thumbnailAttachmentId: undefined,
+  thumbnailStatus: undefined,
   routeLetterIds: [],
 };
 
@@ -52,9 +54,15 @@ export default function CreateStoryTrack() {
     return (
       form.title.trim().length > 0 &&
       form.description.trim().length > 0 &&
-      form.thumbnailAttachmentId !== undefined
+      form.thumbnailAttachmentId !== undefined &&
+      form.thumbnailStatus === "TEMP" // TEMP 상태(필터링 완료)일 때만 다음 단계 가능
     );
-  }, [form.title, form.description, form.thumbnailAttachmentId]);
+  }, [
+    form.title,
+    form.description,
+    form.thumbnailAttachmentId,
+    form.thumbnailStatus,
+  ]);
 
   // step2 검증: 최소 2개 이상 선택해야 제출 가능
   const canSubmitFromStep2 = useMemo(() => {
@@ -77,7 +85,7 @@ export default function CreateStoryTrack() {
     try {
       setIsSubmitting(true);
 
-      // FormState → CreateStorytrackRequest 변환
+      // FormState -> CreateStorytrackRequest 변환
       // canSubmitFromStep2와 canGoNextFromStep1 검증을 통과했으므로 thumbnailAttachmentId는 반드시 존재
       const payload: CreateStorytrackRequest = {
         title: form.title.trim(),
@@ -145,6 +153,7 @@ export default function CreateStoryTrack() {
                   description: form.description,
                   order: form.order,
                   thumbnailAttachmentId: form.thumbnailAttachmentId,
+                  thumbnailStatus: form.thumbnailStatus,
                 }}
                 onChange={(patch: Partial<FirstFormValue>) =>
                   setForm((prev) => ({ ...prev, ...patch }))

--- a/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
+++ b/src/components/dashboard/storyTrack/new/CreateStoryTrack.tsx
@@ -18,7 +18,7 @@ type FormState = {
   title: string;
   description: string;
   order: TrackType;
-  imageFile: File | null;
+  thumbnailAttachmentId?: number;
 
   // step2
   routeLetterIds: string[];
@@ -32,7 +32,7 @@ const initialState: FormState = {
   title: "",
   description: "",
   order: "SEQUENTIAL",
-  imageFile: null,
+  thumbnailAttachmentId: undefined,
   routeLetterIds: [],
 };
 
@@ -52,9 +52,9 @@ export default function CreateStoryTrack() {
     return (
       form.title.trim().length > 0 &&
       form.description.trim().length > 0 &&
-      form.imageFile !== null
+      form.thumbnailAttachmentId !== undefined
     );
-  }, [form.title, form.description, form.imageFile]);
+  }, [form.title, form.description, form.thumbnailAttachmentId]);
 
   // step2 검증: 최소 2개 이상 선택해야 제출 가능
   const canSubmitFromStep2 = useMemo(() => {
@@ -85,6 +85,7 @@ export default function CreateStoryTrack() {
         isPublic: 1, // 기본값: 공개
         price: 0, // 기본값: 무료
         capsuleList: form.routeLetterIds.map((id) => Number(id)), // string[] → number[]
+        attachmentId: form.thumbnailAttachmentId, // 썸네일 attachmentId
       };
 
       // API 호출
@@ -142,7 +143,7 @@ export default function CreateStoryTrack() {
                   title: form.title,
                   description: form.description,
                   order: form.order,
-                  imageFile: form.imageFile,
+                  thumbnailAttachmentId: form.thumbnailAttachmentId,
                 }}
                 onChange={(patch: Partial<FirstFormValue>) =>
                   setForm((prev) => ({ ...prev, ...patch }))

--- a/src/components/dashboard/storyTrack/new/FirstForm.tsx
+++ b/src/components/dashboard/storyTrack/new/FirstForm.tsx
@@ -1,27 +1,211 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 "use client";
 
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
+import toast from "react-hot-toast";
+import {
+  storytrackAttachmentApi,
+  type StorytrackAttachmentStatus,
+} from "@/lib/api/dashboard/storyTrackAttachment";
 
 type Props = {
   value: FirstFormValue;
   onChange: (patch: Partial<FirstFormValue>) => void;
 };
 
+function getErrorMessage(err: unknown) {
+  if (err && typeof err === "object" && "code" in err) {
+    const apiError = err as { code?: string; message?: string };
+    if (apiError.message) {
+      return apiError.message;
+    }
+  }
+
+  if (err instanceof Error) return err.message;
+
+  if (err && typeof err === "object") {
+    const errObj = err as Record<string, unknown>;
+    const response = errObj?.response as
+      | { data?: { message?: unknown; error?: unknown } }
+      | undefined;
+    const candidate =
+      response?.data?.message ?? response?.data?.error ?? errObj?.message;
+
+    if (typeof candidate === "string") return candidate;
+  }
+
+  return "이미지 업로드에 실패했습니다.";
+}
+
 export default function FirstForm({ value, onChange }: Props) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploadedAttachment, setUploadedAttachment] = useState<{
+    attachmentId: number;
+    fileName: string;
+    previewUrl: string;
+    status: StorytrackAttachmentStatus;
+  } | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const pollingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // 파일 프리뷰 URL 생성/해제
   useEffect(() => {
-    if (!value.imageFile) {
-      setPreviewUrl(null);
+    if (uploadedAttachment?.previewUrl) {
+      setPreviewUrl(uploadedAttachment.previewUrl);
       return;
     }
-    const url = URL.createObjectURL(value.imageFile);
-    setPreviewUrl(url);
-    return () => URL.revokeObjectURL(url);
-  }, [value.imageFile]);
+    setPreviewUrl(null);
+  }, [uploadedAttachment]);
+
+  // 이미지 필터링 상태 폴링 함수
+  const pollAttachmentStatus = async (
+    attachmentId: number,
+    onStatusChange: (status: StorytrackAttachmentStatus) => void
+  ) => {
+    // 기존 폴링이 있다면 취소
+    if (pollingTimeoutRef.current) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+
+    const poll = async () => {
+      try {
+        const { status } = await storytrackAttachmentApi.getStatus(
+          attachmentId
+        );
+        onStatusChange(status);
+
+        // TEMP 또는 DELETED 상태면 폴링 종료
+        if (status === "TEMP" || status === "DELETED") {
+          pollingTimeoutRef.current = null;
+          return;
+        }
+
+        // 2초 후 다시 폴링
+        const timeoutId = setTimeout(poll, 2000);
+        pollingTimeoutRef.current = timeoutId;
+      } catch (error) {
+        console.error(`Failed to poll status for ${attachmentId}:`, error);
+        onStatusChange("DELETED"); // 오류 발생 시 DELETED로 처리
+        pollingTimeoutRef.current = null;
+      }
+    };
+
+    // 초기 지연 후 폴링 시작
+    const initialTimeoutId = setTimeout(poll, 500);
+    pollingTimeoutRef.current = initialTimeoutId;
+  };
+
+  // 이미지 파일 선택 핸들러
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    // 이미지 파일만 허용
+    if (!file.type.startsWith("image/")) {
+      toast.error(`${file.name}: 이미지 파일만 업로드할 수 있습니다.`);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    // 파일 크기 제한
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error(`${file.name}: 파일 크기는 10MB 이하여야 합니다.`);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      // 미리보기 URL 생성 (로컬)
+      const previewUrl = URL.createObjectURL(file);
+
+      // Presigned URL 방식으로 업로드
+      const response = await storytrackAttachmentApi.uploadByPresignedUrl(file);
+
+      // 업로드 완료 후 상태를 PENDING으로 설정하고 폴링 시작
+      const newAttachment = {
+        attachmentId: response.attachmentId,
+        fileName: file.name,
+        previewUrl,
+        status: "PENDING" as StorytrackAttachmentStatus, // 업로드 완료, 필터링 대기 중
+      };
+      setUploadedAttachment(newAttachment);
+
+      // 부모 컴포넌트에 attachmentId 전달
+      onChange({ thumbnailAttachmentId: response.attachmentId });
+
+      // 폴링 시작: 상태가 TEMP 또는 DELETED가 될 때까지 조회
+      pollAttachmentStatus(response.attachmentId, (status) => {
+        setUploadedAttachment((prev) => {
+          if (!prev || prev.attachmentId !== response.attachmentId) {
+            return prev;
+          }
+
+          const prevStatus = prev.status;
+
+          // DELETED로 변경되었을 때 토스트 표시
+          if (prevStatus !== "DELETED" && status === "DELETED") {
+            toast.error(
+              `${prev.fileName}: 유해 이미지로 검열되어 삭제되었습니다.`
+            );
+            // DELETED 상태면 부모 컴포넌트에서 attachmentId 제거
+            onChange({ thumbnailAttachmentId: undefined });
+          }
+
+          return {
+            ...prev,
+            status,
+          };
+        });
+      });
+
+      toast.success("이미지 업로드를 시작했습니다!");
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  // 이미지 삭제 핸들러
+  const handleRemoveAttachment = async () => {
+    if (!uploadedAttachment) return;
+
+    try {
+      await storytrackAttachmentApi.deleteTemp(uploadedAttachment.attachmentId);
+      // previewUrl cleanup
+      if (uploadedAttachment.previewUrl) {
+        URL.revokeObjectURL(uploadedAttachment.previewUrl);
+      }
+      setUploadedAttachment(null);
+      // 부모 컴포넌트에서 attachmentId 제거
+      onChange({ thumbnailAttachmentId: undefined });
+      toast.success("이미지가 삭제되었습니다.");
+    } catch {
+      toast.error("이미지 삭제에 실패했습니다.");
+    }
+  };
+
+  // 컴포넌트 언마운트 시 폴링 정리
+  useEffect(() => {
+    return () => {
+      if (pollingTimeoutRef.current) {
+        clearTimeout(pollingTimeoutRef.current);
+        pollingTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   return (
     <div className="h-full min-h-0">
@@ -102,14 +286,13 @@ export default function FirstForm({ value, onChange }: Props) {
               </label>
 
               <input
+                ref={fileInputRef}
                 id="img"
                 type="file"
                 accept="image/*"
-                onChange={(e) => {
-                  const file = e.target.files?.[0] ?? null;
-                  onChange({ imageFile: file });
-                }}
-                className="cursor-pointer border border-outline rounded-lg py-2 px-4 outline-none file:mr-4 file:rounded-md file:border-0 file:bg-button-hover file:px-3 file:py-1.5 file:text-sm file:text-text hover:file:bg-outline/40"
+                onChange={handleFileSelect}
+                disabled={isUploading}
+                className="cursor-pointer border border-outline rounded-lg py-2 px-4 outline-none file:mr-4 file:rounded-md file:border-0 file:bg-button-hover file:px-3 file:py-1.5 file:text-sm file:text-text hover:file:bg-outline/40 disabled:opacity-50 disabled:cursor-not-allowed"
               />
             </div>
 

--- a/src/components/dashboard/storyTrack/new/FirstForm.tsx
+++ b/src/components/dashboard/storyTrack/new/FirstForm.tsx
@@ -141,8 +141,11 @@ export default function FirstForm({ value, onChange }: Props) {
       };
       setUploadedAttachment(newAttachment);
 
-      // 부모 컴포넌트에 attachmentId 전달
-      onChange({ thumbnailAttachmentId: response.attachmentId });
+      // 부모 컴포넌트에 attachmentId와 상태 전달
+      onChange({
+        thumbnailAttachmentId: response.attachmentId,
+        thumbnailStatus: "PENDING",
+      });
 
       // 폴링 시작: 상태가 TEMP 또는 DELETED가 될 때까지 조회
       pollAttachmentStatus(response.attachmentId, (status) => {
@@ -153,13 +156,22 @@ export default function FirstForm({ value, onChange }: Props) {
 
           const prevStatus = prev.status;
 
-          // DELETED로 변경되었을 때 토스트 표시
-          if (prevStatus !== "DELETED" && status === "DELETED") {
-            toast.error(
-              `${prev.fileName}: 유해 이미지로 검열되어 삭제되었습니다.`
-            );
+          // 상태 변경 시 부모에게 전달
+          if (status === "DELETED") {
+            // DELETED로 변경되었을 때 토스트 표시
+            if (prevStatus !== "DELETED") {
+              toast.error(
+                `${prev.fileName}: 유해 이미지로 검열되어 삭제되었습니다.`
+              );
+            }
             // DELETED 상태면 부모 컴포넌트에서 attachmentId 제거
-            onChange({ thumbnailAttachmentId: undefined });
+            onChange({
+              thumbnailAttachmentId: undefined,
+              thumbnailStatus: "DELETED",
+            });
+          } else {
+            // 다른 상태 변경 시에도 부모에게 전달
+            onChange({ thumbnailStatus: status });
           }
 
           return {

--- a/src/components/dashboard/storyTrack/new/FirstForm.tsx
+++ b/src/components/dashboard/storyTrack/new/FirstForm.tsx
@@ -7,6 +7,7 @@ import {
   storytrackAttachmentApi,
   type StorytrackAttachmentStatus,
 } from "@/lib/api/dashboard/storyTrackAttachment";
+import { useCleanupStorytrackTempFile } from "@/lib/hooks/useCleanupStorytrackTempFile";
 
 type Props = {
   value: FirstFormValue;
@@ -48,6 +49,7 @@ export default function FirstForm({ value, onChange }: Props) {
   const [isUploading, setIsUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pollingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const uploadedAttachmentRef = useRef(uploadedAttachment);
 
   // 파일 프리뷰 URL 생성/해제
   useEffect(() => {
@@ -196,6 +198,16 @@ export default function FirstForm({ value, onChange }: Props) {
       toast.error("이미지 삭제에 실패했습니다.");
     }
   };
+
+  // uploadedAttachment 변경 시 ref 업데이트
+  useEffect(() => {
+    uploadedAttachmentRef.current = uploadedAttachment;
+  }, [uploadedAttachment]);
+
+  // 임시 파일 자동 정리 훅 사용
+  // ㄴ 브라우저 탭 나가기 (beforeunload)
+  // ㄴ 컴포넌트 언마운트 (뒤로가기, 페이지 이동 등)
+  useCleanupStorytrackTempFile(uploadedAttachmentRef);
 
   // 컴포넌트 언마운트 시 폴링 정리
   useEffect(() => {

--- a/src/lib/api/dashboard/storyTrackAttachment.ts
+++ b/src/lib/api/dashboard/storyTrackAttachment.ts
@@ -1,0 +1,175 @@
+import { apiFetchRaw } from "../fetchClient";
+
+/**
+ * 파일 업로드 응답 DTO
+ */
+export type StorytrackAttachmentUploadResponse = {
+  attachmentId: number;
+  s3Key: string | null;
+  presignedUrl: string | null;
+  expireAt: string | null; // ISO 8601 형식
+};
+
+/**
+ * Presigned URL 업로드 요청 DTO
+ */
+export type StorytrackAttachmentUploadRequest = {
+  filename: string;
+  mimeType: string;
+  size: number;
+};
+
+/**
+ * 파일 업로드 상태 타입
+ */
+export type StorytrackAttachmentStatus =
+  | "UPLOADING" // 업로드 중
+  | "PENDING" // 이미지 필터링 중
+  | "TEMP" // 임시 저장 완료 (필터링 성공)
+  | "DELETED" // 삭제 또는 필터링 실패
+  | "USED"; // 스토리트랙에 첨부됨
+
+/**
+ * 상태 조회 응답 DTO
+ */
+export type StorytrackAttachmentStatusResponse = {
+  attachmentId: number;
+  status: StorytrackAttachmentStatus;
+};
+
+/**
+ * 스토리트랙 파일 업로드 API
+ */
+export const storytrackAttachmentApi = {
+  /**
+   * Presigned URL 업로드 방식
+   * - 1단계: 메타데이터만 서버에 전송하여 presignedUrl 받기
+   * - 2단계: 받은 presignedUrl로 S3에 직접 업로드
+   * - 3단계: S3 업로드 완료 후 서버에 완료 알림
+   * - 응답: attachmentId + s3Key + presignedUrl + expireAt
+   */
+  uploadByPresignedUrl: async (
+    file: File,
+    signal?: AbortSignal
+  ): Promise<StorytrackAttachmentUploadResponse> => {
+    // 1단계: Presigned URL 요청
+    const request: StorytrackAttachmentUploadRequest = {
+      filename: file.name,
+      mimeType: file.type,
+      size: file.size,
+    };
+
+    const response = await apiFetchRaw<{
+      code: string;
+      message: string;
+      data: StorytrackAttachmentUploadResponse;
+    }>("/api/v1/storytrack/upload/presign", {
+      method: "POST",
+      json: request,
+      signal,
+    });
+
+    const { attachmentId, presignedUrl, s3Key } = response.data;
+
+    if (!presignedUrl) {
+      throw new Error("Presigned URL을 받지 못했습니다.");
+    }
+
+    // 2단계: S3에 직접 업로드
+    // 백엔드에서 Presigned URL 생성 시 contentType과 contentLength를 서명에 포함하지 않았으므로
+    // 프론트엔드에서도 이 헤더들을 보내지 않음
+    const uploadResponse = await fetch(presignedUrl, {
+      method: "PUT",
+      body: file,
+      headers: {},
+      credentials: "omit", // Crucial for S3 direct upload
+      signal,
+    });
+
+    if (!uploadResponse.ok) {
+      const errorText = await uploadResponse.text().catch(() => "");
+      // XML 에러 응답 파싱 시도
+      let errorMessage = `S3 업로드에 실패했습니다. (${uploadResponse.status}: ${uploadResponse.statusText})`;
+      try {
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(errorText, "text/xml");
+        const code = xmlDoc.getElementsByTagName("Code")[0]?.textContent;
+        const message = xmlDoc.getElementsByTagName("Message")[0]?.textContent;
+        if (code || message) {
+          errorMessage = `S3 업로드 실패: ${code || ""} - ${message || ""}`;
+        }
+      } catch {
+        // XML 파싱 실패 시 원본 에러 메시지 사용
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    // 3단계: 서버에 업로드 완료 알림
+    await storytrackAttachmentApi.completeUpload(attachmentId, signal);
+
+    return {
+      attachmentId,
+      s3Key: s3Key ?? null,
+      presignedUrl: null, // 업로드 완료 후에는 null로 설정
+      expireAt: response.data.expireAt,
+    };
+  },
+
+  /**
+   * 업로드 완료 요청
+   * - S3 업로드 완료 후 서버에 알림
+   * - 서버에서 이미지 필터링 시작 (비동기)
+   */
+  completeUpload: async (
+    attachmentId: number,
+    signal?: AbortSignal
+  ): Promise<void> => {
+    await apiFetchRaw<{
+      code: string;
+      message: string;
+      data: Record<string, never>;
+    }>(`/api/v1/storytrack/upload/presign/${attachmentId}`, {
+      method: "POST",
+      signal,
+    });
+  },
+
+  /**
+   * 업로드 상태 조회
+   * - 이미지 필터링 상태 확인용
+   */
+  getStatus: async (
+    attachmentId: number,
+    signal?: AbortSignal
+  ): Promise<StorytrackAttachmentStatusResponse> => {
+    const response = await apiFetchRaw<{
+      code: string;
+      message: string;
+      data: StorytrackAttachmentStatusResponse;
+    }>(`/api/v1/storytrack/upload/presign/${attachmentId}`, {
+      method: "GET",
+      signal,
+    });
+
+    return response.data;
+  },
+
+  /**
+   * 임시 파일 삭제
+   */
+  deleteTemp: async (
+    attachmentId: number,
+    signal?: AbortSignal
+  ): Promise<void> => {
+    await apiFetchRaw<{
+      code: string;
+      message: string;
+      data: Record<string, never>;
+    }>(`/api/v1/storytrack/upload/${attachmentId}`, {
+      method: "DELETE",
+      signal,
+    });
+  },
+};
+

--- a/src/lib/hooks/useCleanupStorytrackTempFile.ts
+++ b/src/lib/hooks/useCleanupStorytrackTempFile.ts
@@ -1,0 +1,82 @@
+import { useEffect, useCallback, RefObject } from "react";
+
+type Attachment = {
+  attachmentId: number;
+  fileName: string;
+  previewUrl?: string;
+};
+
+/**
+ * 스토리트랙 썸네일 임시 파일을 자동으로 정리하는 커스텀 훅
+ *
+ * - 브라우저 탭 나가기 (beforeunload)
+ * - 컴포넌트 언마운트 (뒤로가기, 페이지 이동 등)
+ *
+ * @param uploadedAttachmentRef 업로드된 파일을 담고 있는 ref (단일 객체 또는 null)
+ */
+export function useCleanupStorytrackTempFile(
+  uploadedAttachmentRef: RefObject<Attachment | null>
+) {
+  const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+
+  /**
+   * 임시 파일 삭제 함수
+   * useCallback으로 메모이제이션하여 의존성 문제 해결
+   */
+  const cleanupFile = useCallback(
+    (attachment: Attachment | null) => {
+      if (!attachment) return;
+
+      try {
+        // fetch with keepalive 옵션으로 페이지 이탈 후에도 요청이 전송되도록
+        fetch(
+          `${API_BASE}/api/v1/storytrack/upload/${attachment.attachmentId}`,
+          {
+            method: "DELETE",
+            keepalive: true,
+            credentials: "include", // 쿠키 기반 인증을 위해 필요
+          }
+        ).catch(() => {
+          // 실패해도 무시 (서버 스케줄러가 처리)
+        });
+      } catch {
+        // 무시
+      }
+
+      // 미리보기 URL 정리
+      if (attachment.previewUrl) {
+        URL.revokeObjectURL(attachment.previewUrl);
+      }
+    },
+    [API_BASE]
+  );
+
+  // 브라우저 탭 나가기 시 임시 파일 삭제 (beforeunload)
+  // 참고: beforeunload에서는 비동기 작업이 완료되지 않을 수 있으므로,
+  // fetch with keepalive 옵션 사용하여 페이지 이탈 후에도 요청이 전송되도록 함
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      // beforeunload 시점에 최신 ref 값을 읽어야 하므로 ref.current 직접 사용
+      const attachment = uploadedAttachmentRef.current;
+      cleanupFile(attachment);
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [uploadedAttachmentRef, cleanupFile]);
+
+  // 컴포넌트 언마운트 시 (뒤로가기, 페이지 이동, 취소 버튼 클릭 등) 임시 파일 삭제
+  useEffect(() => {
+    return () => {
+      // cleanup 함수는 언마운트 시점에 실행되며, 이 시점의 최신 ref 값을 읽어야 함
+      // cleanup 시점에 ref.current를 읽는 것은 의도적인 동작 (최신 값을 읽기 위해)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const attachment = uploadedAttachmentRef.current;
+      cleanupFile(attachment);
+    };
+  }, [uploadedAttachmentRef, cleanupFile]);
+}
+

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -13,7 +13,7 @@ type FirstFormValue = {
   title: string;
   description: string;
   order: TrackType;
-  thumbnailAttachmentId?: number; // 썸네일 attachmentId
+  thumbnailAttachmentId: number | undefined;
 };
 
 type MemberType = "CREATOR" | "NOT_JOINED" | "PARTICIPANT" | "COMPLETED";
@@ -52,7 +52,7 @@ type CreateStorytrackRequest = {
   isPublic: number; // 0: 비공개, 1: 공개
   price: number;
   capsuleList: number[]; // capsuleId 배열
-  attachmentId?: number; // 썸네일 attachmentId (선택)
+  attachmentId: number; // 썸네일 attachmentId (필수)
 };
 
 /* 스토리트랙 생성 응답 */

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -13,7 +13,8 @@ type FirstFormValue = {
   title: string;
   description: string;
   order: TrackType;
-  thumbnailAttachmentId: number | undefined;
+  thumbnailAttachmentId: number | undefined; // 썸네일 attachmentId (필수, 초기값은 undefined)
+  thumbnailStatus?: "UPLOADING" | "PENDING" | "TEMP" | "DELETED" | "USED"; // 썸네일 상태
 };
 
 type MemberType = "CREATOR" | "NOT_JOINED" | "PARTICIPANT" | "COMPLETED";

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -13,7 +13,7 @@ type FirstFormValue = {
   title: string;
   description: string;
   order: TrackType;
-  imageFile: File | null;
+  thumbnailAttachmentId?: number; // 썸네일 attachmentId
 };
 
 type MemberType = "CREATOR" | "NOT_JOINED" | "PARTICIPANT" | "COMPLETED";

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -52,6 +52,7 @@ type CreateStorytrackRequest = {
   isPublic: number; // 0: 비공개, 1: 공개
   price: number;
   capsuleList: number[]; // capsuleId 배열
+  attachmentId?: number; // 썸네일 attachmentId (선택)
 };
 
 /* 스토리트랙 생성 응답 */


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

스토리트랙 생성 시 썸네일 이미지 업로드 기능을 Presigned URL 방식으로 구현했습니다. 
스토리트랙은 **1개의 썸네일 파일만 업로드 가능**하며 **썸네일은 필수 항목**입니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #132 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 스토리트랙 썸네일 업로드 API 함수 구현 (`storytrackAttachmentApi`)
  - [x] `uploadByPresignedUrl`: Presigned URL 방식 업로드
  - [x] `completeUpload`: 업로드 완료 알림
  - [x] `getStatus`: 이미지 필터링 상태 조회
  - [x] `deleteTemp`: 임시 파일 삭제
- [x] 이미지 업로드 상태 타입 정의 (`StorytrackAttachmentStatus`)
  - `UPLOADING`: 업로드 중
  - `PENDING`: 이미지 필터링 중
  - `TEMP`: 임시 저장 완료 (필터링 성공)
  - `DELETED`: 삭제 또는 필터링 실패
  - `USED`: 스토리트랙에 첨부됨
- [x] 타입 정의 수정
  - [x] `FirstFormValue`에 `thumbnailAttachmentId` 필드 추가 (필수)
  - [x] `CreateStorytrackRequest`에 `attachmentId` 필드 추가 (필수)
- [x] FirstForm 컴포넌트 업로드 로직 구현
  - [x] Presigned URL 방식 파일 업로드
  - [x] 업로드 완료 후 상태 폴링 (`pollAttachmentStatus`)
  - [x] 업로드 상태별 UI 표시 (업로드 중, 검토 중, 필터링 실패)
  - [x] 업로드/검토 중 파일 선택 버튼 비활성화
  - [x] DELETED 상태 이미지 자동 제거 및 토스트 알림
  - [x] 이미지 삭제 기능 (`handleRemoveAttachment`)
- [x] CreateStoryTrack 컴포넌트 통합
  - [x] Step1 검증 로직 수정 (썸네일 필수, TEMP 상태일 때만 다음 단계 가능)
  - [x] 업로드/검토 중 "다음 단계" 버튼 비활성화
  - [x] 스토리트랙 생성 요청 시 `attachmentId` 포함
- [x] 임시 파일 자동 정리 로직
  - [x] 커스텀 훅 구현 (`useCleanupStorytrackTempFile`)
  - [x] 브라우저 탭 닫기/뒤로가기 시 임시 파일 자동 삭제
  - [x] 컴포넌트 언마운트 시 임시 파일 정리
- [x] 반응형 UI 개선
  - [x] 이미지 입력 폼 width에 따라 반응형으로 조정
  - [x] 업로드 상태 메시지 위치 조정

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->


## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

- **썸네일은 필수 항목**: `thumbnailAttachmentId`가 없거나 상태가 `TEMP`가 아니면 다음 단계로 진행할 수 없습니다.
- **캡슐 이미지 업로드와의 차이점**: 
  - 스토리트랙은 1개의 파일만 업로드 가능 (캡슐은 최대 10개)
  - 썸네일은 필수 항목 (캡슐 이미지는 선택)


## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

배포환경에서만 확인이 가능합니다.
- 폴링 로직이 올바르게 정리되는지 (`setTimeout` cleanup)
- 업로드/검토 중 상태에서 파일 선택 및 다음 단계 버튼이 적절히 비활성화되는지
- 에러 처리 및 토스트 메시지가 적절한지


