### PR TITLE
feat(image-display): presignedUrl을 통한 이미지 표시를 위해 img 태그로 변경

### DIFF
--- a/src/components/capsule/detail/LetterDetailModal.tsx
+++ b/src/components/capsule/detail/LetterDetailModal.tsx
@@ -915,12 +915,15 @@ export default function LetterDetailModal({
                   {capsule.attachments && capsule.attachments.length > 0 && (
                     <div className="flex flex-col gap-3 mt-4 items-start">
                       {capsule.attachments.map((attachment) => (
-                        <div key={attachment.attachmentId} className="relative">
-                          <Image
+                        <div
+                          key={attachment.attachmentId}
+                          className="relative w-full max-h-96"
+                        >
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
                             src={attachment.presignedUrl}
                             alt={`첨부 이미지 ${attachment.attachmentId}`}
-                            fill
-                            className="max-h-96 h-auto object-contain"
+                            className="max-h-96 w-auto h-auto object-contain rounded-lg"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
                               target.style.display = "none";

--- a/src/components/dashboard/storyTrack/all/TrackCard.tsx
+++ b/src/components/dashboard/storyTrack/all/TrackCard.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ListOrdered, MapPin, Shuffle, Users } from "lucide-react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { storyTrackApi } from "@/lib/api/dashboard/storyTrack";
@@ -169,11 +168,13 @@ export default function TrackCard({ track }: { track: StoryTrackItem }) {
         className="relative isolate border border-outline rounded-xl overflow-hidden group"
         onClick={handleCardClick}
       >
-        <Image
-          src={track.imageUrl || "https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={
+            track.imageUrl ||
+            "https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"
+          }
           alt={track.title}
-          width={800}
-          height={200}
           className="w-full h-40 object-cover"
           draggable={false}
         />

--- a/src/components/dashboard/storyTrack/all/TrackCard.tsx
+++ b/src/components/dashboard/storyTrack/all/TrackCard.tsx
@@ -170,7 +170,7 @@ export default function TrackCard({ track }: { track: StoryTrackItem }) {
         onClick={handleCardClick}
       >
         <Image
-          src="https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"
+          src={track.imageUrl || "https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"}
           alt={track.title}
           width={800}
           height={200}

--- a/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackDetailPage.tsx
@@ -152,7 +152,7 @@ export default function TrackDetailPage() {
             {/* Left */}
             <div className="lg:flex-1 lg:min-w-80 flex flex-col gap-4 lg:gap-6 min-h-0">
               <div className="border border-outline rounded-2xl overflow-hidden">
-                <TrackHeader />
+                <TrackHeader imageUrl={data?.data.imageUrl} />
               </div>
 
               <div className="border border-outline rounded-2xl lg:flex-1 lg:min-h-0 overflow-hidden">

--- a/src/components/dashboard/storyTrack/detail/TrackHeader.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackHeader.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-
 const DEFAULT_THUMBNAIL =
   "https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg";
 
@@ -12,12 +10,11 @@ export default function TrackHeader({ imageUrl }: Props) {
 
   return (
     <div className="relative w-full h-44 sm:h-56 lg:h-64 rounded-2xl overflow-hidden">
-      <Image
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
         src={thumbnailUrl}
         alt="대표 이미지"
-        fill
-        className="object-cover"
-        priority
+        className="w-full h-full object-cover"
       />
     </div>
   );

--- a/src/components/dashboard/storyTrack/detail/TrackHeader.tsx
+++ b/src/components/dashboard/storyTrack/detail/TrackHeader.tsx
@@ -1,10 +1,19 @@
 import Image from "next/image";
 
-export default function TrackHeader() {
+const DEFAULT_THUMBNAIL =
+  "https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg";
+
+type Props = {
+  imageUrl?: string | null;
+};
+
+export default function TrackHeader({ imageUrl }: Props) {
+  const thumbnailUrl = imageUrl || DEFAULT_THUMBNAIL;
+
   return (
     <div className="relative w-full h-44 sm:h-56 lg:h-64 rounded-2xl overflow-hidden">
       <Image
-        src="https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"
+        src={thumbnailUrl}
         alt="대표 이미지"
         fill
         className="object-cover"

--- a/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
+++ b/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
@@ -4,11 +4,15 @@ import { ListOrdered, MapPin, Shuffle, TrendingUp, Users } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 
+const DEFAULT_THUMBNAIL =
+  "https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg";
+
 export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
   // 진행률 계산
   const total = track.totalSteps ?? 0;
   const done = track.completedSteps ?? 0;
   const percent = total > 0 ? Math.round((done / total) * 100) : 0;
+  const thumbnailUrl = track.imageUrl || DEFAULT_THUMBNAIL;
 
   return (
     <Link
@@ -18,7 +22,7 @@ export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
       <div className="relative">
         {/* Top */}
         <Image
-          src="https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"
+          src={thumbnailUrl}
           alt={track.title}
           width={800}
           height={200}

--- a/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
+++ b/src/components/dashboard/storyTrack/joined/JoinedCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ListOrdered, MapPin, Shuffle, TrendingUp, Users } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 
 const DEFAULT_THUMBNAIL =
@@ -21,11 +20,10 @@ export default function JoinedCard({ track }: { track: StoryTrackJoinedItem }) {
     >
       <div className="relative">
         {/* Top */}
-        <Image
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
           src={thumbnailUrl}
           alt={track.title}
-          width={800}
-          height={200}
           className="w-full h-40 object-cover rounded-t-xl"
         />
 

--- a/src/components/dashboard/storyTrack/mine/MineCard.tsx
+++ b/src/components/dashboard/storyTrack/mine/MineCard.tsx
@@ -1,5 +1,4 @@
 import { ListOrdered, MapPin, Shuffle, Users } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 
 const DEFAULT_THUMBNAIL =
@@ -14,11 +13,10 @@ export default function MineCard({ track }: { track: StoryTrackMineItem }) {
       className="block border border-outline rounded-xl hover:shadow-md transition"
     >
       {/* Top */}
-      <Image
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
         src={thumbnailUrl}
         alt={track.title}
-        width={800}
-        height={200}
         className="w-full h-40 object-cover rounded-t-xl"
       />
 

--- a/src/components/dashboard/storyTrack/mine/MineCard.tsx
+++ b/src/components/dashboard/storyTrack/mine/MineCard.tsx
@@ -2,7 +2,12 @@ import { ListOrdered, MapPin, Shuffle, Users } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 
+const DEFAULT_THUMBNAIL =
+  "https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg";
+
 export default function MineCard({ track }: { track: StoryTrackMineItem }) {
+  const thumbnailUrl = track.imageUrl || DEFAULT_THUMBNAIL;
+
   return (
     <Link
       href={`/dashboard/storyTrack/${track.storytrackId}`}
@@ -10,7 +15,7 @@ export default function MineCard({ track }: { track: StoryTrackMineItem }) {
     >
       {/* Top */}
       <Image
-        src="https://cdn.pixabay.com/photo/2024/01/15/21/13/puppy-8510899_1280.jpg"
+        src={thumbnailUrl}
         alt={track.title}
         width={800}
         height={200}

--- a/src/type/storyTrack.d.ts
+++ b/src/type/storyTrack.d.ts
@@ -32,6 +32,7 @@ type StoryTrackItem = {
   createdAt: string;
   totalMemberCount: number;
   memberType: MemberType;
+  imageUrl?: string | null; // 썸네일 이미지 URL
 };
 
 type StoryTrackListPage = {
@@ -114,6 +115,7 @@ type StoryTrackJoinedItem = {
   completedAt: string | null;
   createdAt: string;
   totalMemberCount: number;
+  imageUrl?: string | null; // 썸네일 이미지 URL
 };
 
 type StoryTrackJoinedListPage = {
@@ -138,6 +140,7 @@ type StoryTrackMineItem = {
   totalSteps: number;
   createdAt: string;
   totalMemberCount: number;
+  imageUrl?: string | null; // 썸네일 이미지 URL
 };
 
 type StoryTrackMineListPage = {
@@ -166,6 +169,7 @@ type StoryTrackDetailItem = {
   memberType: MemberType;
   paths: StoryTrackPaths;
   completedCapsuleId: number[];
+  imageUrl?: string | null; // 썸네일 이미지 URL
 };
 
 type StoryTrackPaths = {
@@ -207,6 +211,7 @@ type StoryTrackProgressItem = {
   lastCompletedStep: number;
   completedAt: string;
   createdAt: string;
+  imageUrl?: string | null; // 썸네일 이미지 URL
 };
 
 type StoryTrackProgressResponse = ApiEnvelope<StoryTrackProgressItem>;


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

Presigned URL을 사용하는 이미지들이 Next.js Image Optimization을 거치면서 발생하는 400 에러를 해결하기 위해, presigned URL을 사용하는 이미지 표시를 Next.js `Image` 컴포넌트에서 일반 `<img>` 태그로 변경했습니다. 또한 스토리트랙 썸네일 이미지 표시 기능을 구현했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

### 캡슐 이미지 첨부 표시 수정
- [x] `LetterDetailModal.tsx`: Next.js `Image` 컴포넌트를 일반 `<img>` 태그로 변경
  - Presigned URL이 포함된 긴 쿼리 파라미터를 Next.js Image Optimization이 처리하지 못하는 문제 해결

### 스토리트랙 썸네일 표시 기능 구현
- [x] 타입 정의 수정: `StoryTrackMineItem`, `StoryTrackJoinedItem`, `StoryTrackItem`, `StoryTrackDetailItem`, `StoryTrackProgressItem`에 `imageUrl?: string | null` 필드 추가
- [x] `MineCard.tsx`: 업로드한 썸네일 이미지 표시 (없으면 기본 이미지)
- [x] `JoinedCard.tsx`: 업로드한 썸네일 이미지 표시 (없으면 기본 이미지)
- [x] `TrackCard.tsx`: 업로드한 썸네일 이미지 표시 (없으면 기본 이미지)
- [x] `TrackHeader.tsx`: 상세 페이지에서 썸네일 이미지 표시 (없으면 기본 이미지)
- [x] 모든 스토리트랙 썸네일 컴포넌트: Next.js `Image` 컴포넌트를 일반 `<img>` 태그로 변경 (presigned URL 직접 로드)

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

- 캡슐 상세 페이지에서 첨부 이미지가 정상적으로 표시됨
- 스토리트랙 리스트 및 상세 페이지에서 업로드한 썸네일 이미지가 정상적으로 표시됨

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

- **Presigned URL은 일반 `<img>` 태그 사용**: Next.js `Image` 컴포넌트는 presigned URL의 긴 쿼리 파라미터(특히 `X-Amz-Security-Token`)를 처리하지 못해 400 에러가 발생합니다. 따라서 presigned URL은 반드시 일반 `<img>` 태그로 표시해야 합니다.

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->

